### PR TITLE
[ofono] Disable udev modem autodetection

### DIFF
--- a/sparse/var/lib/environment/ofono/noplugin.conf
+++ b/sparse/var/lib/environment/ofono/noplugin.conf
@@ -2,5 +2,5 @@ OFONO_ARGS=--noplugin=he910,dun_gw_bluez5,hfp_bluez5,hfp_ag_bluez5,\
 cdma_provision,bluez5,isimodem,n900,u8500,qmimodem,gobi,cdmamodem,isiusb,\
 nwmodem,ztemodem,iceramodem,huaweimodem,calypsomodem,swmodem,mbmmodem,\
 hsomodem,ifxmodem,stemodem,dunmodem,hfpmodem,speedupmodem,phonesim,\
-telitmodem
+telitmodem,udev,udevng
 


### PR DESCRIPTION
this commit removes udev autodetection from ofono