### PR TITLE
[configs] Increase maximum inotify instance count limit. MER#1136

### DIFF
--- a/sparse/etc/sysctl.d/fs-settings.conf
+++ b/sparse/etc/sysctl.d/fs-settings.conf
@@ -1,0 +1,2 @@
+#Set maximum inotify instances limit
+fs.inotify.max_user_instances = 8192


### PR DESCRIPTION
Some processes (eg. connman) can use more inotify intances
than the default (128) allowed, therefore the limit needs
to be raised.