### PR TITLE
[adb] Adapt to the new adbd functionfs. Contributes: JB#30264

### DIFF
--- a/sparse/lib/systemd/system/adbd.service
+++ b/sparse/lib/systemd/system/adbd.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Android Debug Bridge Daemon
+
 [Service]
 Environment=PATH=/sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin
+ExecStartPre=/usr/sbin/adbd-functionfs.sh
 ExecStart=/sbin/adbd
+ExecStopPost=/bin/sleep 1 ; /bin/umount adb

--- a/sparse/usr/sbin/adbd-functionfs.sh
+++ b/sparse/usr/sbin/adbd-functionfs.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+mkdir -p /dev/usb-ffs
+chmod 0770 /dev/usb-ffs
+chown shell:shell /dev/usb-ffs
+mkdir -p /dev/usb-ffs/adb
+chmod 0770 /dev/usb-ffs/adb
+chown shell:shell /dev/usb-ffs/adb
+/bin/mount -t functionfs adb /dev/usb-ffs/adb -o uid=shell,gid=shell
+exit 0


### PR DESCRIPTION
   Add functionfs helper, this is backwards compatible with the
   old adb.
