### PR TITLE
Add configuration for passing alien process id.

### DIFF
--- a/sparse/etc/ohm/dbus_signal_conf.ini
+++ b/sparse/etc/ohm/dbus_signal_conf.ini
@@ -5,3 +5,11 @@ interface = org.nemomobile.compositor
 signature = i
 arguments = pid
 target = active_application_request
+
+[alien_signal]
+name = alienProcessIdChanged
+path = /org/nemomobile/policy
+interface = org.nemomobile.policy
+signature = i
+arguments = pid
+target = alien_application_request


### PR DESCRIPTION
Add D-Bus signal listening configuration for passing alien application
UI process id to OHM. This information is then used to map topmost
application pid to determine correct media state.
Unless alien is used this configuration change has no effect.