### PR TITLE
[adb] Add the adbd-prepare service. Contributes: JB#30264

### DIFF
--- a/sparse/lib/systemd/system/adbd-prepare.service
+++ b/sparse/lib/systemd/system/adbd-prepare.service
@@ -1,0 +1,18 @@
+# Copyright (C) 2013 Jolla Oy
+#
+# Prepare functionfs for adbd 
+ 
+[Unit]
+Description=functionfs setup for adbd
+Before=adbd.service
+PartOf=adbd.service
+
+[Service]
+Type=notify
+RemainAfterExit=yes
+ExecStart=/usr/sbin/adbd-functionfs.sh
+ExecStop=/bin/umount adb
+
+[Install]
+WantedBy=graphical.target
+

--- a/sparse/lib/systemd/system/adbd.service
+++ b/sparse/lib/systemd/system/adbd.service
@@ -3,6 +3,4 @@ Description=Android Debug Bridge Daemon
 
 [Service]
 Environment=PATH=/sbin:/vendor/bin:/system/sbin:/system/bin:/system/xbin
-ExecStartPre=/usr/sbin/adbd-functionfs.sh
 ExecStart=/sbin/adbd
-ExecStopPost=/bin/sleep 1 ; /bin/umount adb


### PR DESCRIPTION
We need to add a systemd service to set up the functionfs
before starting adbd.

Signed-off-by: Philippe De Swert <philippe.deswert@jollamobile.com>