### PR TITLE
[actdead] Add configurable kernel parameter check for actdead mode.

### DIFF
--- a/sparse/usr/lib/startup/preinit/get_bootstate
+++ b/sparse/usr/lib/startup/preinit/get_bootstate
@@ -35,6 +35,12 @@
 
 check_bogus=0
 bootreason_str="Normal boot"
+actdead_bootparam=""
+
+if [ -f /var/lib/environment/actdead/bootparam.conf ]; then
+    source /var/lib/environment/actdead/bootparam.conf
+    actdead_bootparam=$ACTDEAD_PARAMETER_STRING
+fi
 
 if grep -q 'jolla.test_mode=USER' /proc/cmdline; then
     # Device is in QA test mode forcing USER
@@ -45,6 +51,12 @@ elif grep -q 'jolla.test_mode=ACT_DEAD' /proc/cmdline; then
 elif grep -q 'androidboot.mode=charger' /proc/cmdline; then
     BOOTSTATE="ACT_DEAD"
     bootreason_str="androidboot.mode=charger"
+    check_bogus=1
+elif [ ! -z "$actdead_bootparam" ] &&
+     grep -q $actdead_bootparam /proc/cmdline; then
+    # Device specific boot parameter
+    BOOTSTATE="ACT_DEAD"
+    bootreason_str=$actdead_bootparam
     check_bogus=1
 else
     BOOTSTATE="USER"


### PR DESCRIPTION
On some devices the boot reason is given in different ways, on Sony devices this appears to be given in the "startup" parameter but the value for usb boot reason is different on different devices, for example on Xperia Pro (iyokan) and other msm7x30 based devices the value is 0x00000020 whereas on newer devices such Xperia SP the value is 0x4. Instead of adding a custom check for every different possibility make the boot reason parameter configurable in /var/lib/environment/actdead/bootparam.conf.