### PR TITLE
[configs] Add AltGr keycode to kmap. Contributes to JB#31092

### DIFF
--- a/configs/droid.kmap
+++ b/configs/droid.kmap
@@ -1,3 +1,4 @@
+keycode 100 = AltGr
 keycode 114 = VolumeDown
 keycode 115 = VolumeUp
 keycode 163 = MediaNext


### PR DESCRIPTION
Us layout as overridden default doesn't include AltGr so
it needs to be included separately in droid.kmap.