### PR TITLE
Add default configs for sensors and pulseaudio.

### DIFF
--- a/sparse/etc/pulse/arm_droid_default.pa
+++ b/sparse/etc/pulse/arm_droid_default.pa
@@ -1,0 +1,107 @@
+#!/usr/bin/pulseaudio -nF
+#
+# This file is part of PulseAudio.
+#
+# PulseAudio is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# PulseAudio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with PulseAudio; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+
+# This startup script is used only if PulseAudio is started per-user
+# (i.e. not in system mode)
+
+.nofail
+
+.fail
+
+load-module module-droid-keepalive
+
+load-module module-meego-parameters cache=1 directory=/var/lib/nemo-pulseaudio-parameters use_voice=false
+
+### Automatically restore the volume of streams
+load-module module-stream-restore-nemo restore_device=no restore_volume=yes restore_muted=no route_table=/etc/pulse/x-maemo-route.table fallback_table=/etc/pulse/x-maemo-stream-restore.table use_voice=false sink_volume_table=/etc/pulse/x-maemo-sink-volume.table
+
+load-module module-match table=/etc/pulse/x-maemo-match.table key=application.name
+
+### Automatically augment property information from .desktop files
+### stored in /usr/share/application
+load-module module-augment-properties
+
+load-module module-null-sink sink_name=sink.null rate=48000
+
+load-module module-droid-card rate=48000 mute_routing_before=24576 mute_routing_after=4096
+
+load-module module-null-sink sink_name=sink.fake.sco rate=8000 channels=1
+load-module module-null-source source_name=source.fake.sco rate=8000 channels=1
+load-module module-bluez4-discover sco_sink=sink.fake.sco sco_source=source.fake.sco
+
+load-module module-meego-mainvolume virtual_stream=true
+
+load-module module-policy-enforcement
+
+load-module module-role-ducking trigger_roles=alarm,notification,warning ducking_roles=x-maemo volume=-200dB
+
+### Load several protocols
+.ifexists module-esound-protocol-unix.so
+load-module module-esound-protocol-unix
+.endif
+load-module module-native-protocol-unix
+
+### Network access (may be configured with paprefs, so leave this commented
+### here if you plan to use paprefs)
+#load-module module-esound-protocol-tcp
+#load-module module-native-protocol-tcp
+
+### Load the RTP receiver module (also configured via paprefs, see above)
+#load-module module-rtp-recv
+
+### Load the RTP sender module (also configured via paprefs, see above)
+#load-module module-null-sink sink_name=rtp format=s16be channels=2 rate=44100 sink_properties="device.description='RTP Multicast Sink'"
+#load-module module-rtp-send source=rtp.monitor
+
+### Load additional modules from GConf settings. This can be configured with the paprefs tool.
+### Please keep in mind that the modules configured by paprefs might conflict with manually
+### loaded modules.
+.ifexists module-gconf.so
+.nofail
+load-module module-gconf
+.fail
+.endif
+
+### Make sure we always have a sink around, even if it is a null sink.
+load-module module-always-sink
+
+### Honour intended role device property
+load-module module-intended-roles
+
+### Automatically suspend sinks/sources that become idle for too long
+load-module module-suspend-on-idle timeout=1
+
+### If autoexit on idle is enabled we want to make sure we only quit
+### when no local session needs us anymore.
+.ifexists module-console-kit.so
+load-module module-console-kit
+.endif
+.ifexists module-systemd-login.so
+load-module module-systemd-login
+.endif
+
+### Load DBus protocol
+.ifexists module-dbus-protocol.so
+load-module module-dbus-protocol
+.endif
+
+load-module module-switch-on-port-available
+
+### Make some devices default
+set-default-sink sink.primary
+set-default-source source.primary

--- a/sparse/etc/sensorfw/primaryuse.conf
+++ b/sparse/etc/sensorfw/primaryuse.conf
@@ -1,0 +1,15 @@
+[plugins]
+accelerometeradaptor = hybrisaccelerometeradaptor
+alsadaptor = hybrisalsadaptor
+proximityadaptor = hybrisproximityadaptor
+magnetometeradaptor = hybrismagnetometeradaptor
+gyroscopeadaptor = hybrisgyroscopeadaptor
+orientationadaptor = hybrisorientationadaptor
+ 
+[magnetometer]
+scale_coefficient = 1
+transformation_matrix = "-1,0,0,0,1,0,0,0,1"
+needs_calibration = 0
+ 
+[accelerometer]
+transformation_matrix = "1,0,0,0,1,0,0,0,1"

--- a/sparse/etc/sysconfig/pulseaudio
+++ b/sparse/etc/sysconfig/pulseaudio
@@ -1,0 +1,1 @@
+CONFIG="-n --file=/etc/pulse/arm_droid_default.pa"

--- a/sparse/etc/xdg/QtProject/Sensors.conf
+++ b/sparse/etc/xdg/QtProject/Sensors.conf
@@ -1,0 +1,10 @@
+[Default]
+QAccelerometer=sensorfw.accelerometer
+QAmbientLightSensor=sensorfw.als
+QCompass=sensorfw.compass
+QMagnetometer=sensorfw.magnetometer
+QOrientationSensor=sensorfw.orientationsensor
+QProximitySensor=sensorfw.proximitysensor
+QRotationSensor=sensorfw.rotationsensor
+QLightSensor=sensorfw.lightsensor
+QGyroscope=sensorfw.gyroscope


### PR DESCRIPTION
Most devices use the same configuration files so default files can be added which makes porting easier. If a device needs custom files those can be added to device specific configs.