### PR TITLE
[UI] add default allowed orientations

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -13,6 +13,7 @@
 
 # Device capabilities:
 # have_modem: set this if your device ships a modem
+# allowed_orientations: for phones: 11 (default), for tablets: 15
 # pixel_ratio: UI scaling factor, choose from 1.0, 1.5, 2.0. Any other value will
 # default the icon pack to 1.0 resolution (it is a bug)!
 # Read more on ways to do-it-together: https://bugs.nemomobile.org/show_bug.cgi?id=814
@@ -305,6 +306,12 @@ mkdir -p %{buildroot}/usr/share/package-groups/
 /usr/bin/repomd-pattern-builder.py --patternxml -p %{dcd_common}/patterns/common -o %{buildroot}/usr/share/package-groups/ --version=%{version} --release=%{release}
 /usr/bin/repomd-pattern-builder.py --patternxml -p %{dcd_common}/patterns/hybris -o %{buildroot}/usr/share/package-groups/ --version=%{version} --release=%{release}
 /usr/bin/repomd-pattern-builder.py --patternxml -p %{dcd_path}/patterns/ -o %{buildroot}/usr/share/package-groups/ --version=%{version} --release=%{release}
+
+%if 0%(!?allowed_orientations:1)
+%define allowed_orientations 11
+%endif
+
+sed --in-place 's|@ALLOWED_ORIENTATIONS@|%{allowed_orientations}|' %{buildroot}/etc/dconf/db/vendor.d/silica-configs.txt
 
 %if 0%{!?pixel_ratio:1}
 %define pixel_ratio 1.0

--- a/sparse/etc/dconf/db/vendor.d/silica-configs.txt
+++ b/sparse/etc/dconf/db/vendor.d/silica-configs.txt
@@ -1,3 +1,4 @@
 [desktop/sailfish/silica]
 theme_pixel_ratio=@PIXEL_RATIO@
+default_allowed_orientations=@ALLOWED_ORIENTATIONS@
 


### PR DESCRIPTION
Specifically to shutup this warning when starting any application:
`[W] DeclarativeWindow::DeclarativeWindow:93 - No default allowed orientations defined. Check your device configuration!`

Or does this need to be handled per-device?
