### PR TITLE
Add missing parameter modes.

### DIFF
--- a/sparse/var/lib/nemo-pulseaudio-parameters/modes/btmono-hsp/mainvolume
+++ b/sparse/var/lib/nemo-pulseaudio-parameters/modes/btmono-hsp/mainvolume
@@ -1,0 +1,1 @@
+../../algs/mainvolume/btmono

--- a/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandbtmono-hfp/mainvolume
+++ b/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandbtmono-hfp/mainvolume
@@ -1,0 +1,1 @@
+../../algs/mainvolume/btmono

--- a/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandbtmono-hsp/mainvolume
+++ b/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandbtmono-hsp/mainvolume
@@ -1,0 +1,1 @@
+../../algs/mainvolume/btmono

--- a/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandheadset/mainvolume
+++ b/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandheadset/mainvolume
@@ -1,0 +1,1 @@
+../../algs/mainvolume/ihf

--- a/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandlineout/mainvolume
+++ b/sparse/var/lib/nemo-pulseaudio-parameters/modes/ihfandlineout/mainvolume
@@ -1,0 +1,1 @@
+../../algs/mainvolume/ihf


### PR DESCRIPTION
Due to kind-of-bug in module-meego-parameters if mode definition is
missing and mode (or route) changes to missing mode, parameters module
doesn't report the mode change forward. This then causes bugs further
down the path as certain actions aren't done when mode changes.
Simple fix is to just introduce all modes in the configuration.