### PR TITLE
Update route volume defaults.

### DIFF
--- a/sparse/etc/pulse/x-maemo-route.table
+++ b/sparse/etc/pulse/x-maemo-route.table
@@ -1,2 +1,2 @@
-sink-input-by-media-role:x-maemo -15
-sink-input-by-media-role:phone -15 -28
+sink-input-by-media-role:x-maemo -25
+sink-input-by-media-role:phone -15


### PR DESCRIPTION
Remove minimum volume for phone stream (remove second argument from
sink-input-by-media-role:phone route volume). As the hw adaptation
this configuration is used for doesn't have silent volume for
voicecall there is no need to have minimum volume.

Make default media stream volume a bit quieter, mainly for the sake of
lineout default volume.