### PR TITLE
 [packaging] Subpackages in .spec should not let their files packaged twice

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -422,6 +422,11 @@ if [ -e create.dirs ]; then
   done
 fi
 
+# Delete files from droid-config.files which are packaged in main spec file
+if [ -e packaged-in-main-spec.files ]; then
+  delete_files tmp/droid-config.files packaged-in-main-spec.files 0
+fi
+
 ################################################################
 %post
 # Force an update of ssu repositories


### PR DESCRIPTION
If we have some sub package for droid-config and we need to include
some files into that package it can be done by adding file paths
to packaged-in-main-spec.files

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>