### PR TITLE
WIP Mount /home as part of the systemd multi-user target.

### DIFF
--- a/sparse/lib/systemd/system/home.service
+++ b/sparse/lib/systemd/system/home.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Home directory mount
+Before=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/mount /dev/mapper/sailfish-home /home
+
+[Install]
+WantedBy=multi-user.target

--- a/sparse/lib/systemd/system/multi-user.target.wants/home.service
+++ b/sparse/lib/systemd/system/multi-user.target.wants/home.service
@@ -1,0 +1,1 @@
+../home.service


### PR DESCRIPTION
The separate unit file for mounting home allows a login UI process to
inject itself as a pre-requistite so that the user can be prompted
for a passcode to unlock an encrypted home partition.