### PR TITLE
Use defirent sprase path in one source tree

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -260,7 +260,7 @@ config_files() {
 # specific sparse/ :
 copy_files_from %{dcd_path}/%{dcd_sparse}
 delete_files tmp/droid-config.files delete_file.list 1
-copy_files_from %{dcd_path}/sparse
+copy_files_from %{dcd_path}/sparse-%{rpm_device} 
 delete_files tmp/droid-config.files delete_file_%{rpm_device}.list 1
 # This add %config to %files section for files from rpm-config-files.files
 config_files tmp/droid-config.files rpm-config-files.files


### PR DESCRIPTION
If i use one tree of source code for different device we use one sparce path - It is not comfortable.
After enable this path i use diferent path for device