### PR TITLE
[configs] Modify default platform device udev rule to work on recent devices.

### DIFF
--- a/sparse/lib/udev/platform-device
+++ b/sparse/lib/udev/platform-device
@@ -1,5 +1,5 @@
 #!/bin/sh
-RESULT=`echo "$1" | sed "s|/devices/\([^/]*\)/\([^/]*\)/.*|\1/\2|g"`
+RESULT=`echo "$1" | sed "s|/devices/\([^/]*\)/\([^/]*\)/.*|\1/\2|g"| cut -d'/' -f1`
 
 echo ANDROID_BLOCK_DEVICE=$RESULT
 

--- a/sparse/lib/udev/rules.d/998-droid-system.rules
+++ b/sparse/lib/udev/rules.d/998-droid-system.rules
@@ -10,4 +10,4 @@ SUBSYSTEM=="misc", KERNEL=="log_radio", SYMLINK+="alog/radio"
 SUBSYSTEM=="misc", KERNEL=="log_system", SYMLINK+="alog/system"
 SUBSYSTEM=="misc", KERNEL=="log_main", SYMLINK+="alog/main"
 
-ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", IMPORT{program}="/bin/sh /lib/udev/platform-device $env{DEVPATH}", SYMLINK+="block/$env{ANDROID_BLOCK_DEVICE}/by-name/$env{ID_PART_ENTRY_NAME}"
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", IMPORT{program}="/bin/sh /lib/udev/platform-device $env{DEVPATH}", SYMLINK+="block/platform/$env{ANDROID_BLOCK_DEVICE}/by-name/$env{ID_PART_ENTRY_NAME}"


### PR DESCRIPTION
The old udev rule had issues on most of the recent devices. The new version fixes many things on newer devices. The rule still doesn't work for all devices though but is still much better than the old. A generic rule is a work in progress at the moment.