### PR TITLE
[etc] Add popular symlinks to /system/etc

### DIFF
--- a/sparse/etc/acdbdata
+++ b/sparse/etc/acdbdata
@@ -1,0 +1,1 @@
+/system/etc/acdbdata

--- a/sparse/etc/audio_platform_info.xml
+++ b/sparse/etc/audio_platform_info.xml
@@ -1,0 +1,1 @@
+/system/etc/audio_platform_info.xml

--- a/sparse/etc/gps.conf
+++ b/sparse/etc/gps.conf
@@ -1,0 +1,1 @@
+/system/etc/gps.conf

--- a/sparse/etc/izat.conf
+++ b/sparse/etc/izat.conf
@@ -1,0 +1,1 @@
+/system/etc/izat.conf

--- a/sparse/etc/media_codecs.xml
+++ b/sparse/etc/media_codecs.xml
@@ -1,0 +1,1 @@
+/system/etc/media_codecs.xml

--- a/sparse/etc/media_codecs_ffmpeg.xml
+++ b/sparse/etc/media_codecs_ffmpeg.xml
@@ -1,0 +1,1 @@
+/system/etc/media_codecs_ffmpeg.xml

--- a/sparse/etc/media_codecs_google_audio.xml
+++ b/sparse/etc/media_codecs_google_audio.xml
@@ -1,0 +1,1 @@
+/system/etc/media_codecs_google_audio.xml

--- a/sparse/etc/media_codecs_google_telephony.xml
+++ b/sparse/etc/media_codecs_google_telephony.xml
@@ -1,0 +1,1 @@
+/system/etc/media_codecs_google_telephony.xml

--- a/sparse/etc/media_codecs_google_video.xml
+++ b/sparse/etc/media_codecs_google_video.xml
@@ -1,0 +1,1 @@
+/system/etc/media_codecs_google_video.xml

--- a/sparse/etc/media_profiles.xml
+++ b/sparse/etc/media_profiles.xml
@@ -1,0 +1,1 @@
+/system/etc/media_profiles.xml

--- a/sparse/etc/mixer_paths.xml
+++ b/sparse/etc/mixer_paths.xml
@@ -1,0 +1,1 @@
+/system/etc/mixer_paths.xml

--- a/sparse/etc/sap.conf
+++ b/sparse/etc/sap.conf
@@ -1,0 +1,1 @@
+/system/etc/sap.conf

--- a/sparse/etc/sec_config
+++ b/sparse/etc/sec_config
@@ -1,0 +1,1 @@
+/system/etc/sec_config

--- a/sparse/etc/xtra_root_cert.pem
+++ b/sparse/etc/xtra_root_cert.pem
@@ -1,0 +1,1 @@
+/system/etc/xtra_root_cert.pem

--- a/sparse/etc/xtwifi.conf
+++ b/sparse/etc/xtwifi.conf
@@ -1,0 +1,1 @@
+/system/etc/xtwifi.conf


### PR DESCRIPTION
If some adaptation doesn't need a file or two, it should be safe to keep them
dangling.

If their presence breaks functionality, an adaptation then adds them to its
delete_file.list

Feel free to add more symlinks you found necessary.