### PR TITLE
[quick] Add QtQuick configs. Contributes to JB#38166

### DIFF
--- a/sparse/etc/xdg/QtProject/QtQuick2.conf
+++ b/sparse/etc/xdg/QtProject/QtQuick2.conf
@@ -1,0 +1,2 @@
+[QuickMouseArea]
+PressAndHoldDelay=600


### PR DESCRIPTION
All Sailfish OS devices should have 600ms (vs. Qt default 800ms) long-press delay.