### PR TITLE
Add earpieceforcall for consistency.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -266,6 +266,11 @@ name    = equals:droid_card.primary
 profile = voicecall
 
 [card]
+type    = earpieceforcall
+name    = equals:droid_card.primary
+profile = voicecall
+
+[card]
 type    = earpieceforalien
 name    = equals:droid_card.primary
 profile = communication
@@ -436,6 +441,11 @@ ports = sink.primary:output-earpiece
 
 [device]
 type  = earpiece
+sink  = equals:sink.primary
+ports = sink.primary:output-earpiece
+
+[device]
+type  = earpieceforcall
 sink  = equals:sink.primary
 ports = sink.primary:output-earpiece
 


### PR DESCRIPTION
For consistency's sake earpieceforcall is going to be used in upcoming
policy-settings-common, so that all routes used during voice calls use
forcall suffix. Adding the card and device sections to xpolicy.conf
already now, as they do no harm if they exist before
policy-settings-common changes, but would break if they don't exist when
the update is in place.