### PR TITLE
[configs] Add bootdevice symlinks to udev rules. Needed on most new devices.

### DIFF
--- a/sparse/lib/udev/rules.d/998-droid-system.rules
+++ b/sparse/lib/udev/rules.d/998-droid-system.rules
@@ -11,3 +11,5 @@ SUBSYSTEM=="misc", KERNEL=="log_system", SYMLINK+="alog/system"
 SUBSYSTEM=="misc", KERNEL=="log_main", SYMLINK+="alog/main"
 
 ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", IMPORT{program}="/bin/sh /lib/udev/platform-device $env{DEVPATH}", SYMLINK+="block/platform/$env{ANDROID_BLOCK_DEVICE}/by-name/$env{ID_PART_ENTRY_NAME}"
+
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", IMPORT{program}="/bin/sh /lib/udev/platform-device $env{DEVPATH}", SYMLINK+="block/bootdevice/by-name/$env{ID_PART_ENTRY_NAME}"


### PR DESCRIPTION
Might need some cleanup later but without this symlink all new devices fail to boot.