### PR TITLE
Add bthfp device config.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -216,6 +216,27 @@ name1    = equals:droid_card.primary
 profile1 = communication
 
 [card]
+type    = bthfp
+name0    = startswith:"bluez_card"
+profile0 = droid_hfp
+name1    = equals:droid_card.primary
+profile1 = primary-primary
+
+[card]
+type    = bthfpforcall
+name0    = startswith:"bluez_card"
+profile0 = droid_hfp
+name1    = equals:droid_card.primary
+profile1 = voicecall
+
+[card]
+type    = bthfpforalien
+name0    = startswith:"bluez_card"
+profile0 = droid_hfp
+name1    = equals:droid_card.primary
+profile1 = communication
+
+[card]
 type    = ihfandheadset
 name    = equals:droid_card.primary
 profile = ringtone
@@ -368,6 +389,42 @@ flags = disable_notify, refresh_always, delayed_port_change
 
 [device]
 type   = bthspforalien
+source = equals:source.primary
+ports  = source.primary:input-bluetooth_sco_headset
+flags  = disable_notify, refresh_always
+
+[device]
+type  = bthfp
+sink  = equals:sink.primary
+ports = sink.primary:output-bluetooth_sco
+flags = disable_notify, refresh_always
+
+[device]
+type   = bthfp
+source = equals:source.primary
+ports  = source.primary:input-bluetooth_sco_headset
+flags  = disable_notify, refresh_always
+
+[device]
+type  = bthfpforcall
+sink  = equals:sink.primary
+ports = sink.primary:output-bluetooth_sco
+flags = disable_notify, refresh_always, delayed_port_change
+
+[device]
+type   = bthfpforcall
+source = equals:source.primary
+ports  = source.primary:input-bluetooth_sco_headset
+flags  = disable_notify, refresh_always
+
+[device]
+type  = bthfpforalien
+sink  = equals:sink.primary
+ports = sink.primary:output-bluetooth_sco
+flags = disable_notify, refresh_always, delayed_port_change
+
+[device]
+type   = bthfpforalien
 source = equals:source.primary
 ports  = source.primary:input-bluetooth_sco_headset
 flags  = disable_notify, refresh_always


### PR DESCRIPTION
Even though not currently used with bluez4, add bthfp device
configurations to the xpolicy.conf already.

With bluez5 policy configuration the old bthsp device is split to bthsp
and bthfp, to manage the two profiles easier. Old implementation only
had hwid property with bthsp device which contained the info about which
bluetooth profile was in use. When the two profiles have own devices in
policy configuration managing the routing is much simpler.