### PR TITLE
Prevent removing main HA packages

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -429,6 +429,8 @@ sed --in-place 's|@PIXEL_RATIO@|%{pixel_ratio}|' %{buildroot}/etc/dconf/db/vendo
 sed --in-place 's|@ICON_RES@|%{icon_res}|' %{buildroot}/etc/dconf/db/vendor.d/silica-configs.txt
 sed --in-place 's|@ICON_RES@|%{icon_res}|' %{buildroot}/usr/share/package-groups/*
 
+sed --in-place 's|@DEVICE@|%{rpm_device}|' %{buildroot}/etc/zypp/systemCheck.d/*.check
+
 # SSU board mapping for hardware adaptation
 %if 0%{!?provides_own_board_mapping:1}
 mkdir -p $RPM_BUILD_ROOT/%{board_mapping_dir}

--- a/sparse/etc/zypp/systemCheck.d/ha.check
+++ b/sparse/etc/zypp/systemCheck.d/ha.check
@@ -1,0 +1,6 @@
+requires:droid-hal-@DEVICE@
+requires:droid-config-@DEVICE@
+requires:droid-hal-version-@DEVICE@
+requires:libhybris-libEGL
+requires:libhybris-libGLESv2
+requires:libhybris-libwayland-egl


### PR DESCRIPTION
ha.check file prevents removing main hardware adaptation packages.