### PR TITLE
[patterns] Add Jolla Store and Sideloading for post 2.1.1 builds

### DIFF
--- a/patterns/templates/jolla-configuration-@DEVICE@.yaml
+++ b/patterns/templates/jolla-configuration-@DEVICE@.yaml
@@ -18,6 +18,10 @@ Requires:
 # 3rd party accounts like Twitter, VK, cloud services, etc
 - jolla-settings-accounts-extensions-3rd-party-all
 
+# Introduced starting Sailfish OS 2.1.1.26
+# Required for Jolla Store Access
+- patterns-sailfish-consumer-generic
+
 # For Mozilla location services (online)
 - geoclue-provider-mlsdb
 


### PR DESCRIPTION
Starting from Sailfish OS 2.1.1 these are no longer part of the default build, and need to be specified in the patterns otherwise your build will be missing Jolla Store Client, Jolla Account, and Untrusted Applications settings menu.