### PR TITLE
[shutdown] shutdown gracefully.

### DIFF
--- a/sparse/lib/systemd/system/droid-hal-init.service
+++ b/sparse/lib/systemd/system/droid-hal-init.service
@@ -13,7 +13,7 @@ Conflicts=shutdown.target
 Type=notify
 NotifyAccess=all
 ExecStart=/bin/sh /usr/bin/droid/droid-hal-startup.sh
-ExecStop=/bin/sh /usr/bin/droid/droid-hal-shutdown.sh
+ExecStop=/bin/sh /usr/bin/droid/droid-hal-shutdown.sh %c
 Restart=always
 # Lets make sure we don't block minutes in case of errors.
 TimeoutSec=15


### PR DESCRIPTION
 If the parameter %c is not specified for the droid-hal-shutdown script, The script will just exit without shutting down the services properly. JB#38944 is not regressed by this.