### PR TITLE
Use better default for card profile.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf.d/bluez4.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez4.conf
@@ -13,7 +13,7 @@ profile = ringtone
 [card]
 type    = headset
 name    = equals:droid_card.primary
-profile = primary
+profile = primary-primary
 
 [card]
 type    = headsetforcall
@@ -28,7 +28,7 @@ profile = communication
 [card]
 type    = headphone
 name    = equals:droid_card.primary
-profile = primary
+profile = primary-primary
 
 [card]
 type    = headphoneforcall
@@ -43,7 +43,7 @@ profile = communication
 [card]
 type    = ihfandtvout
 name    = equals:droid_card.primary
-profile = primary
+profile = primary-primary
 
 [card]
 type    = earpiece
@@ -68,7 +68,7 @@ profile = voicecall
 [card]
 type    = ihf
 name    = equals:droid_card.primary
-profile = primary
+profile = primary-primary
 
 [card]
 type    = ihfforalien
@@ -128,7 +128,7 @@ type    = bta2dp
 name0    = startswith:"bluez_card"
 profile0 = a2dp
 name1    = equals:droid_card.primary
-profile1 = primary
+profile1 = primary-primary
 
 [card]
 type    = bta2dpforalien

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
@@ -12,7 +12,7 @@ type    = bta2dp
 name0    = startswith:"bluez_card"
 profile0 = a2dp_sink
 name1    = equals:droid_card.primary
-profile1 = primary
+profile1 = primary-primary
 flags1   = disable_notify
 
 [card]
@@ -28,7 +28,7 @@ type    = bthsp
 name0    = startswith:"bluez_card"
 profile0 = droid_hsp
 name1    = equals:droid_card.primary
-profile1 = primary
+profile1 = primary-primary
 flags1   = disable_notify
 
 [card]
@@ -52,7 +52,7 @@ type    = bthfp
 name0    = startswith:"bluez_card"
 profile0 = droid_hfp
 name1    = equals:droid_card.primary
-profile1 = primary
+profile1 = primary-primary
 flags1   = disable_notify
 
 [card]
@@ -90,7 +90,7 @@ flags1   = disable_notify
 [card]
 type    = headset
 name0   = equals:droid_card.primary
-profile0= primary
+profile0= primary-primary
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
@@ -114,7 +114,7 @@ flags1   = disable_notify
 [card]
 type    = headphone
 name0   = equals:droid_card.primary
-profile0= primary
+profile0= primary-primary
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
@@ -138,7 +138,7 @@ flags1   = disable_notify
 [card]
 type    = ihfandtvout
 name0   = equals:droid_card.primary
-profile0= primary
+profile0= primary-primary
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
@@ -178,7 +178,7 @@ flags1   = disable_notify
 [card]
 type    = ihf
 name0   = equals:droid_card.primary
-profile0= primary
+profile0= primary-primary
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify


### PR DESCRIPTION
With default pulseaudio config (arm_droid_default.pa) primary (a
combined profile) is not generated, so using profile generated always
by default is better default in policy configuration as well.