### PR TITLE
[droid-hal-configs] Use appropriate key code for device's home key. Contributes to JB#17545

### DIFF
--- a/configs/droid.kmap
+++ b/configs/droid.kmap
@@ -15,6 +15,7 @@ keycode 165 = MediaPrevious
 keycode 166 = MediaStop
 keycode 168 = AudioRewind
 keycode 169 = Call
+keycode 172 = HomePage
 keycode 200 = MediaPlay
 keycode 201 = MediaPause
 keycode 208 = AudioForward


### PR DESCRIPTION
Home is used in apps to move focus to the beginning, HomePage is the right one to handle navigation to homescreen.