### PR TITLE
Update PulseAudio configuration.

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -135,9 +135,9 @@ Requires:   ohm-plugin-resolver
 Requires:   ohm-plugin-ruleengine
 Requires:   ohm-plugin-profile
 Requires:   ohm-plugin-route
-Requires:   pulseaudio-modules-nemo-common >= 4.0.11
-Requires:   pulseaudio-policy-enforcement >= 4.0.8
-Requires:   policy-settings-common >= 0.2.7
+Requires:   pulseaudio-modules-nemo-common >= 8.0.24
+Requires:   pulseaudio-policy-enforcement >= 8.0.33
+Requires:   policy-settings-common >= 0.7.3
 Obsoletes:  ohm-config <= 1.1.15
 # ohm-configs-default should not be installed ever, thus no version
 # specification defined here.
@@ -172,12 +172,12 @@ Provides:   droid-config-preinit-plugins
 %package pulseaudio-settings
 Summary:    PulseAudio settings for %{rpm_device} hw
 Provides:   droid-config-pulseaudio-settings
-Requires:   pulseaudio >= 4.0
-Requires:   pulseaudio-modules-nemo-parameters >= 4.0.11
-Requires:   pulseaudio-modules-nemo-stream-restore >= 4.0.11
-Requires:   pulseaudio-modules-nemo-mainvolume >= 4.0.11
-Requires:   pulseaudio-modules-droid >= 4.0.6
-Requires:   pulseaudio-policy-enforcement >= 6.0.20
+Requires:   pulseaudio >= 8.0
+Requires:   pulseaudio-modules-nemo-parameters >= 8.0.24
+Requires:   pulseaudio-modules-nemo-stream-restore >= 8.0.24
+Requires:   pulseaudio-modules-nemo-mainvolume >= 8.0.24
+Requires:   pulseaudio-modules-droid >= 8.0.63
+Requires:   pulseaudio-policy-enforcement >= 8.0.33
 Provides:   pulseaudio-settings
 
 %description pulseaudio-settings

--- a/sparse/etc/pulse/arm_droid_default.pa
+++ b/sparse/etc/pulse/arm_droid_default.pa
@@ -30,12 +30,10 @@ load-module module-meego-mainvolume virtual_stream=true
 
 ### Automatically restore the volume of streams
 # load configuration based on bluez version
-.ifexists /etc/pulse/bluez4_stream_restore.pa
-.include /etc/pulse/bluez4_stream_restore.pa
-.endif
-
 .ifexists /etc/pulse/bluez5_stream_restore.pa
-.include /etc/pulse/bluez5_stream_restore.pa
+ .include /etc/pulse/bluez5_stream_restore.pa
+.else
+ .include /etc/pulse/bluez4_stream_restore.pa
 .endif
 
 load-module module-match table=/etc/pulse/x-maemo-match.table key=application.name
@@ -46,20 +44,24 @@ load-module module-augment-properties
 
 load-module module-null-sink sink_name=sink.null rate=48000
 
-load-module module-droid-card rate=48000 mute_routing_before=24576 mute_routing_after=4096
+### If droid-card needs other arguments than the default, have the new
+### load-module line in /etc/pulse/arm_droid_card_custom.pa
+.ifexists /etc/pulse/arm_droid_card_custom.pa
+ .include /etc/pulse/arm_droid_card_custom.pa
+.else
+ load-module module-droid-card rate=48000
+.endif
 
 ### Needed on many new devices. HADK guide explains how to implement this fully
 .ifexists module-droid-glue.so
-.nofail
-load-module module-droid-glue
-.fail
+ .nofail
+ load-module module-droid-glue
+ .fail
 .endif
 
 load-module module-null-sink sink_name=sink.fake.sco rate=8000 channels=1
 load-module module-null-source source_name=source.fake.sco rate=8000 channels=1
 load-module module-bluetooth-discover bluez4_args="sco_sink=sink.fake.sco sco_source=source.fake.sco" bluez5_args="headset=droid"
-
-load-module module-combine-sink sink_name=sink.primaryandbluez resample_method=trivial rate=48000 channels=2 ignore=sink.low_latency
 
 load-module module-policy-enforcement
 
@@ -115,8 +117,7 @@ load-module module-systemd-login
 load-module module-dbus-protocol
 .endif
 
+### Move orphan streams to placeholder sinks or sources so that playback doesn't get
+### interrupted. Policy enforcement module then moves the streams to new appropriate
+### sinks or sources.
 load-module module-rescue-streams sink_name=sink.null source_name=sink.null.monitor
-
-### Make some devices default
-set-default-sink sink.primary
-set-default-source source.primary

--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -1,3 +1,45 @@
+# -------- xpolicy.conf --------------------------------------------------------
+#
+# Files are read in following order,
+# 1) xpolicy.conf
+# 2) xpolicy.conf.d/*.conf, in descending order
+#
+# Variables can be defined anywhere, and they affect all the conf files. Variables
+# are updated if same variable is defined later on (for example variables in
+# xpolicy.conf.d/xvars.conf are applied most likely latest and are the active
+# ones). Variables can be used to replace any string configuration value
+# (NOT match types, etc.). For example following stream definition is valid:
+#
+# [stream]
+# property = $property_name@equals:$property_value
+# group    = $group_name
+#
+# or for context definition following property action is valid:
+# set-property = sink-name@equals:$sink, property:$string, value@constant:$value
+#
+# Other sections than [variable] can also be defined in any conf file, and already
+# defined ones will be overridden by later definition.
+#
+
+
+# -------- Variable section ----------------------------------------------------
+
+# Defaults. To override define variables with new values
+# in xpolicy.conf.d directory (for example xpolicy.conf.d/xvars.conf).
+[variable]
+# sinks, sources and ports
+droid_source_input_microphone = input-builtin_mic
+droid_source_input_backmicrophone = input-back_mic
+droid_source_input_fmradio = input-fm_tuner
+droid_sink_port_change_delay = delayed_port_change
+delay_time = 150
+# cards and profiles
+droid_card = droid_card.primary
+droid_card_profile = default
+# bluetooth sco
+droid_sco_output = output-bluetooth_sco
+droid_sco_input = input-bluetooth_sco_headset
+
 # -------- Group section -------------------------------------------------------
 
 [group]
@@ -9,122 +51,102 @@ source = sink.null.monitor
 [group]
 name   = background
 flags  = limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
+sink   = droid.output.media_latency@equals:"true"
+source = droid.input.builtin@equals:"true"
 
 [group]
 name   = systemsound
 flags  = set_sink, limit_volume, cork_stream, mute_by_route
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.media_latency@equals:"true"
 
 [group]
 name   = btnotify
-flags  = set_sink, limit_volume, cork_stream, mute_by_route
-sink   = sink.primaryandbluez
-source = sink.null.monitor
+flags  = set_sink, limit_volume, cork_stream, mute_by_route, dynamic_sink
+sink   = startswith:"bluez_sink"
 
 [group]
 name   = feedbacksound
 flags  = set_sink, limit_volume, cork_stream, mute_by_route
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.low_latency@equals:"true"
 
 [group]
 name   = inputsound
 flags  = set_sink, limit_volume, cork_stream, mute_by_route
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.low_latency@equals:"true"
 
 [group]
 name   = event
 flags  = set_sink, limit_volume, cork_stream, mute_by_route
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.media_latency@equals:"true"
 
 [group]
 name   = alarm
 flags  = set_sink, limit_volume, cork_stream
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.media_latency@equals:"true"
 
 [group]
 name   = flash
 flags  = limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
 
 [group]
 name   = player
 flags  = route_audio, limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
 
 [group]
 name   = game
 flags  = route_audio, limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
 
 [group]
 name   = voiceui
 flags  = set_sink, limit_volume, cork_stream
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.low_latency@equals:"true"
 
 [group]
 name   = ringtone
-flags  = limit_volume, mute_by_route, cork_stream, media_notify
-sink   = sink.primary
-source = source.null.monitor
+flags  = set_sink, limit_volume, mute_by_route, cork_stream, media_notify
+sink   = droid.output.media_latency@equals:"true"
 
 [group]
 name   = camera
 flags  = set_sink, set_source, limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
+sink   = droid.output.media_latency@equals:"true"
+source = droid.input.builtin@equals:"true"
 
 [group]
 name   = videoeditor
 flags  = route_audio, limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
 
 [group]
 name   = ipcall
 flags  = set_sink, set_source, limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
+sink   = droid.output.low_latency@equals:"true"
+source = droid.input.builtin@equals:"true"
 
 [group]
 name   = call
 flags  = set_sink, set_source
-sink   = sink.primary
-source = source.primary
+sink   = droid.output.low_latency@equals:"true"
+source = droid.input.builtin@equals:"true"
 
 [group]
 name   = navigator
 flags  = set_sink, set_source
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.media_latency@equals:"true"
+source = droid.input.builtin@equals:"true"
 
 [group]
 name   = cstone
 flags  = route_audio, set_source, limit_volume
-sink   = sink.primary
-source = sink.null.monitor
 
 [group]
 name   = alwayson
 flags  = set_sink, limit_volume, cork_stream
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.media_latency@equals:"true"
 
 [group]
 name   = nonsilent
 flags  = set_sink, limit_volume, cork_stream
-sink   = sink.primary
-source = sink.null.monitor
+sink   = droid.output.media_latency@equals:"true"
 
 [group]
 name   = internal
@@ -135,27 +157,23 @@ source = source.null.monitor
 [group]
 name   = outgoing
 flags  = route_audio
-sink   = sink.primary
-source = sink.null.monitor
 
 [group]
 name   = incoming
 flags  = route_audio
-sink   = sink.null
-source = source.primary
 
 [group]
 name   = alien
 flags  = route_audio, limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
 
 [group]
 name   = aliencall
 flags  = route_audio, limit_volume, cork_stream
-sink   = sink.primary
-source = source.primary
 
+[group]
+name   = probesink
+flags  = set_sink, limit_volume, cork_stream
+sink   = droid.output.media_latency@equals:"true"
 
 # -------- Card section --------------------------------------------------------
 
@@ -163,222 +181,229 @@ source = source.primary
 
 [device]
 type = tvoutandbta2dp
-sink = name@startswith:"bluez_sink"
+sink = startswith:"bluez_sink"
 
 [device]
 type  = ihfandheadset
-sink  = equals:sink.primary
-ports = sink.primary:output-speaker+wired_headphone
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-speaker+wired_headphone
+flags = $droid_sink_port_change_delay
+delay = $delay_time
 
 [device]
 type  = ihfandheadset
-source= equals:source.primary
-ports = source.primary:input-wired_headset
+source= droid.input.external@equals:"true"
+ports = droid.input.external@equals:"true"->input-wired_headset
 
 [device]
 type  = ihfandheadphone
-sink  = equals:sink.primary
-ports = sink.primary:output-speaker+wired_headphone
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-speaker+wired_headphone
+flags = $droid_sink_port_change_delay
+delay = $delay_time
 
 [device]
 type  = bta2dp
-sink  = name@startswith:"bluez_sink"
-ports = sink.primary:output-speaker
+sink  = startswith:"bluez_sink"
+ports = droid.output.primary@equals:"true"->output-speaker
 flags = disable_notify
 
 [device]
 type  = bta2dpforalien
-sink  = name@startswith:"bluez_sink"
-ports = sink.primary:output-speaker
+sink  = startswith:"bluez_sink"
+ports = droid.output.primary@equals:"true"->output-speaker
 flags = disable_notify
 
 [device]
 type  = bthsp
-sink  = equals:sink.primary
-ports = sink.primary:output-bluetooth_sco
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->$droid_sco_output
 flags = disable_notify, refresh_always
 
 [device]
 type   = bthsp
-source = equals:source.primary
-ports  = source.primary:input-bluetooth_sco_headset
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->$droid_sco_input
 flags  = disable_notify, refresh_always
 
 [device]
 type  = bthspforcall
-sink  = equals:sink.primary
-ports = sink.primary:output-bluetooth_sco
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->$droid_sco_output
 flags = disable_notify, refresh_always, delayed_port_change
 
 [device]
 type   = bthspforcall
-source = equals:source.primary
-ports  = source.primary:input-bluetooth_sco_headset
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->$droid_sco_input
 flags  = disable_notify, refresh_always
 
 [device]
 type  = bthspforalien
-sink  = equals:sink.primary
-ports = sink.primary:output-bluetooth_sco
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->$droid_sco_output
 flags = disable_notify, refresh_always, delayed_port_change
 
 [device]
 type   = bthspforalien
-source = equals:source.primary
-ports  = source.primary:input-bluetooth_sco_headset
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->$droid_sco_input
 flags  = disable_notify, refresh_always
 
 [device]
 type  = bthfp
-sink  = equals:sink.primary
-ports = sink.primary:output-bluetooth_sco
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->$droid_sco_output
 flags = disable_notify, refresh_always
 
 [device]
 type   = bthfp
-source = equals:source.primary
-ports  = source.primary:input-bluetooth_sco_headset
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->$droid_sco_input
 flags  = disable_notify, refresh_always
 
 [device]
 type  = bthfpforcall
-sink  = equals:sink.primary
-ports = sink.primary:output-bluetooth_sco
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->$droid_sco_output
 flags = disable_notify, refresh_always, delayed_port_change
 
 [device]
 type   = bthfpforcall
-source = equals:source.primary
-ports  = source.primary:input-bluetooth_sco_headset
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->$droid_sco_input
 flags  = disable_notify, refresh_always
 
 [device]
 type  = bthfpforalien
-sink  = equals:sink.primary
-ports = sink.primary:output-bluetooth_sco
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->$droid_sco_output
 flags = disable_notify, refresh_always, delayed_port_change
 
 [device]
 type   = bthfpforalien
-source = equals:source.primary
-ports  = source.primary:input-bluetooth_sco_headset
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->$droid_sco_input
 flags  = disable_notify, refresh_always
 
 [device]
-type = headset
-source = equals:source.primary
-ports = source.primary:input-wired_headset
-flags = disable_notify, refresh_always
+type   = headset
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->input-wired_headset
+flags  = disable_notify, refresh_always
 
 [device]
 type  = headset
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headset
-flags = disable_notify, refresh_always
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headset
+flags = disable_notify, refresh_always, $droid_sink_port_change_delay
+delay = $delay_time
 
 [device]
 type  = headsetforcall
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headset
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headset
 flags = refresh_always
 
 [device]
-type = headsetforcall
-source = equals:source.primary
-ports = source.primary:input-wired_headset
+type   = headsetforcall
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->input-wired_headset
 
 [device]
 type  = headsetforalien
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headset
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headset
 flags = refresh_always
 
 [device]
-type = headsetforalien
-source = equals:source.primary
-ports = source.primary:input-wired_headset
+type   = headsetforalien
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->input-wired_headset
 
 [device]
 type  = headphone
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headphone
-flags = disable_notify, refresh_always
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headphone
+flags = disable_notify, refresh_always, $droid_sink_port_change_delay
+delay = $delay_time
 
 [device]
 type  = headphoneforcall
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headphone
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headphone
 flags = refresh_always
 
 [device]
 type  = headphoneforalien
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headphone
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headphone
 flags = refresh_always
 
 [device]
 type  = ihfandtvout
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headset
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headphone
 
 [device]
 type  = tvout
-sink  = equals:sink.primary
-ports = sink.primary:output-wired_headset
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-wired_headphone
 
 [device]
 type  = earpieceandtvout
-sink  = equals:sink.primary
-ports = sink.primary:output-earpiece
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
 
 [device]
 type  = earpieceforcall
-sink  = equals:sink.primary
-ports = sink.primary:output-earpiece
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
 
 [device]
 type  = earpiece
-sink  = equals:sink.primary
-ports = sink.primary:output-earpiece
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
 
 [device]
 type  = earpieceforalien
-sink  = equals:sink.primary
-ports = sink.primary:output-earpiece
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
 flags = refresh_always
 
 [device]
 type   = microphone
-source = equals:source.primary
-ports = source.primary:input-builtin_mic
+source = droid.input.builtin@equals:"true"
+ports  = droid.input.builtin@equals:"true"->$droid_source_input_microphone
 
 [device]
 type   = backmicrophone
-source = equals:source.primary
-ports = source.primary:input-back_mic
+source = droid.input.builtin@equals:"true"
+ports = droid.input.builtin@equals:"true"->$droid_source_input_backmicrophone
 
 [device]
 type  = ihf
-sink  = equals:sink.primary
-ports = sink.primary:output-speaker
-flags = refresh_always
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-speaker
+flags = refresh_always, $droid_sink_port_change_delay
+delay = $delay_time
 
 [device]
 type  = ihfforcall
-sink  = equals:sink.primary
-ports = sink.primary:output-speaker
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-speaker
 flags = refresh_always
 
 [device]
 type  = ihfforalien
-sink  = equals:sink.primary
-ports = sink.primary:output-speaker
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-speaker
 flags = refresh_always
 
 [device]
-type  = voicecall
-source= equals:source.primary
-ports = source.primary:input-voice_call
+type   = voicecall
+source = droid.input.external@equals:"true"
+ports  = droid.input.external@equals:"true"->input-voice_call
 
 [device]
 type = null
@@ -399,19 +424,20 @@ exe      = pacat
 group    = player
 
 # Ignore pulsesink probe from gstreamer pulsesink
+# when a2dp is active, route probing to a2dp headset
 [stream]
 property = media.name@equals:"pulsesink probe"
-group    = internal
+sink     = bta2dp
+group    = btnotify
+
+# Ignore pulsesink probe from gstreamer pulsesink
+[stream]
+property = media.name@equals:"pulsesink probe"
+group    = probesink
 
 [stream]
 exe      = ngfd
 property = media.name@equals:"system-event"
-sink     = bta2dp
-group    = btnotify
-
-[stream]
-exe      = ngfd
-property = event.id@equals:"alarm-clock-elapsed"
 sink     = bta2dp
 group    = btnotify
 
@@ -502,11 +528,11 @@ name     = "Virtual Stream for MainVolume Volume Control"
 group    = internal
 
 [stream]
-name  = "output of sink.primary"
+name  = "output of sink."
 group = internal
 
 [stream]
-name  = "input of source.primary"
+name  = "input of source."
 group = internal
 
 [stream]
@@ -523,19 +549,19 @@ group    = internal
 [context-rule]
 variable     = call
 value        = equals:outgoing
-set-property = sink-name@equals:"sink.primary", property:"x-nemo.voicecall.status", value@constant:"active"
+set-property = module-name@equals:module-policy-enforcement, property:"x-nemo.voicecall.status", value@constant:"active"
 
 [context-rule]
 variable     = call
 value        = equals:active
-set-property = sink-name@equals:"sink.primary", property:"x-nemo.voicecall.status", value@constant:"active"
+set-property = module-name@equals:module-policy-enforcement, property:"x-nemo.voicecall.status", value@constant:"active"
 
 [context-rule]
 variable     = call
 value        = equals:inactive
-set-property = sink-name@equals:"sink.primary", property:"x-nemo.voicecall.status", value@constant:"inactive"
+set-property = module-name@equals:module-policy-enforcement, property:"x-nemo.voicecall.status", value@constant:"inactive"
 
 [context-rule]
 variable     = media_state
 value        = matches:"^[^t].*"
-set-property = sink-name@equals:"sink.primary", property:"x-nemo.media.state", value@copy-from-context
+set-property = module-name@equals:module-policy-enforcement, property:"x-nemo.media.state", value@copy-from-context

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez4.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez4.conf
@@ -2,119 +2,119 @@
 
 [card]
 type    = ihfandheadset
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = ringtone
 
 [card]
 type    = ihfandheadphone
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = ringtone
 
 [card]
 type    = headset
-name    = equals:droid_card.primary
-profile = primary-primary
+name    = equals:$droid_card
+profile = $droid_card_profile
 
 [card]
 type    = headsetforcall
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = voicecall
 
 [card]
 type    = headsetforalien
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = communication
 
 [card]
 type    = headphone
-name    = equals:droid_card.primary
-profile = primary-primary
+name    = equals:$droid_card
+profile = $droid_card_profile
 
 [card]
 type    = headphoneforcall
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = voicecall
 
 [card]
 type    = headphoneforalien
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = communication
 
 [card]
 type    = ihfandtvout
-name    = equals:droid_card.primary
-profile = primary-primary
+name    = equals:$droid_card
+profile = $droid_card_profile
 
 [card]
 type    = earpiece
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = voicecall
 
 [card]
 type    = earpieceforcall
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = voicecall
 
 [card]
 type    = earpieceforalien
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = communication
 
 [card]
 type    = ihfforcall
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = voicecall
 
 [card]
 type    = ihf
-name    = equals:droid_card.primary
-profile = primary-primary
+name    = equals:$droid_card
+profile = $droid_card_profile
 
 [card]
 type    = ihfforalien
-name    = equals:droid_card.primary
+name    = equals:$droid_card
 profile = communication
 
 [card]
 type    = bthsp
 name0    = startswith:"bluez_card"
 profile0 = hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = voicecall
 
 [card]
 type    = bthspforcall
 name0    = startswith:"bluez_card"
 profile0 = hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = voicecall
 
 [card]
 type    = bthspforalien
 name0    = startswith:"bluez_card"
 profile0 = hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = communication
 
 [card]
 type    = bthfp
 name0    = startswith:"bluez_card"
 profile0 = hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = voicecall
 
 [card]
 type    = bthfpforcall
 name0    = startswith:"bluez_card"
 profile0 = hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = voicecall
 
 [card]
 type    = bthfpforalien
 name0    = startswith:"bluez_card"
 profile0 = hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = communication
 
 [card]
@@ -127,14 +127,14 @@ flags   = disable_notify
 type    = bta2dp
 name0    = startswith:"bluez_card"
 profile0 = a2dp
-name1    = equals:droid_card.primary
-profile1 = primary-primary
+name1    = equals:$droid_card
+profile1 = $droid_card_profile
 
 [card]
 type    = bta2dpforalien
 name0    = startswith:"bluez_card"
 profile0 = a2dp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = communication
 
 # -------- Context rule section ------------------------------------------------

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
@@ -6,20 +6,19 @@ name    = startswith:"bluez_card"
 profile = a2dp
 flags   = disable_notify
 
-
 [card]
 type    = bta2dp
 name0    = startswith:"bluez_card"
 profile0 = a2dp_sink
-name1    = equals:droid_card.primary
-profile1 = primary-primary
+name1    = equals:$droid_card
+profile1 = $droid_card_profile
 flags1   = disable_notify
 
 [card]
 type    = bta2dpforalien
 name0    = startswith:"bluez_card"
 profile0 = a2dp_sink
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = communication
 flags1   = disable_notify
 
@@ -27,15 +26,15 @@ flags1   = disable_notify
 type    = bthsp
 name0    = startswith:"bluez_card"
 profile0 = droid_hsp
-name1    = equals:droid_card.primary
-profile1 = primary-primary
+name1    = equals:$droid_card
+profile1 = $droid_card_profile
 flags1   = disable_notify
 
 [card]
 type    = bthspforcall
 name0    = startswith:"bluez_card"
 profile0 = droid_hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = voicecall
 flags1   = disable_notify
 
@@ -43,7 +42,7 @@ flags1   = disable_notify
 type    = bthspforalien
 name0    = startswith:"bluez_card"
 profile0 = droid_hsp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = communication
 flags1   = disable_notify
 
@@ -51,15 +50,15 @@ flags1   = disable_notify
 type    = bthfp
 name0    = startswith:"bluez_card"
 profile0 = droid_hfp
-name1    = equals:droid_card.primary
-profile1 = primary-primary
+name1    = equals:$droid_card
+profile1 = $droid_card_profile
 flags1   = disable_notify
 
 [card]
 type    = bthfpforcall
 name0    = startswith:"bluez_card"
 profile0 = droid_hfp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = voicecall
 flags1   = disable_notify
 
@@ -67,13 +66,13 @@ flags1   = disable_notify
 type    = bthfpforalien
 name0    = startswith:"bluez_card"
 profile0 = droid_hfp
-name1    = equals:droid_card.primary
+name1    = equals:$droid_card
 profile1 = communication
 flags1   = disable_notify
 
 [card]
 type    = ihfandheadset
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= ringtone
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -81,7 +80,7 @@ flags1   = disable_notify
 
 [card]
 type    = ihfandheadphone
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= ringtone
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -89,15 +88,15 @@ flags1   = disable_notify
 
 [card]
 type    = headset
-name0   = equals:droid_card.primary
-profile0= primary-primary
+name0   = equals:$droid_card
+profile0= $droid_card_profile
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
 
 [card]
 type    = headsetforcall
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= voicecall
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -105,7 +104,7 @@ flags1   = disable_notify
 
 [card]
 type    = headsetforalien
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= communication
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -113,15 +112,15 @@ flags1   = disable_notify
 
 [card]
 type    = headphone
-name0   = equals:droid_card.primary
-profile0= primary-primary
+name0   = equals:$droid_card
+profile0= $droid_card_profile
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
 
 [card]
 type    = headphoneforcall
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= voicecall
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -129,7 +128,7 @@ flags1   = disable_notify
 
 [card]
 type    = headphoneforalien
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= communication
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -137,15 +136,15 @@ flags1   = disable_notify
 
 [card]
 type    = ihfandtvout
-name0   = equals:droid_card.primary
-profile0= primary-primary
+name0   = equals:$droid_card
+profile0= $droid_card_profile
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
 
 [card]
 type    = earpiece
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= voicecall
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -153,7 +152,7 @@ flags1   = disable_notify
 
 [card]
 type    = earpieceforcall
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= voicecall
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -161,7 +160,7 @@ flags1   = disable_notify
 
 [card]
 type    = earpieceforalien
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= communication
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -169,7 +168,7 @@ flags1   = disable_notify
 
 [card]
 type    = ihfforcall
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= voicecall
 name1    = startswith:"bluez_card"
 profile1 = off
@@ -177,17 +176,16 @@ flags1   = disable_notify
 
 [card]
 type    = ihf
-name0   = equals:droid_card.primary
-profile0= primary-primary
+name0   = equals:$droid_card
+profile0= $droid_card_profile
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
 
 [card]
 type    = ihfforalien
-name0   = equals:droid_card.primary
+name0   = equals:$droid_card
 profile0= communication
 name1    = startswith:"bluez_card"
 profile1 = off
 flags1   = disable_notify
-


### PR DESCRIPTION
Instead of relying on absolute sink or source names for routing targets,
use property flags.

This config change requires packages and dependencies for
pulseaudio-modules-droid >= 8.0.63
pulseaudio-policy-enforcement >= 8.0.33
