### PR TITLE
Add default configs for usb-otg audio and fmradio.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf.d/fmradio.conf.disabled
+++ b/sparse/etc/pulse/xpolicy.conf.d/fmradio.conf.disabled
@@ -1,0 +1,35 @@
+# To enable PulseAudio fmradio device configuration make a symlink from
+# this file to fmradio.conf in sparse/etc/pulse/xpolicy.conf.d
+# If input fm port is different from default add
+# sparse/etc/pulse/xpolicy.conf.d/xvars.conf with input port name
+# used in your device.
+
+[device]
+type  = headphoneasfmradio
+source= droid.input.external@equals:true
+ports = droid.input.external@equals:true->$droid_source_input_fmradio
+flags = refresh_always
+
+[device]
+type  = headphoneasfmradiolp
+source= droid.input.external@equals:true
+ports = droid.input.external@equals:true->$droid_source_input_fmradio
+module= module-loopback@sink_input_properties='media.role=x-maemo%20media.name=fmradio-loopback'%20latency_msec=250%20reset_on_attach=true
+flags = refresh_always, module_unload_immediately
+
+[device]
+type  = headsetasfmradio
+source= droid.input.external@equals:true
+ports = droid.input.external@equals:true->$droid_source_input_fmradio
+flags = refresh_always
+
+[device]
+type  = headsetasfmradiolp
+source= droid.input.external@equals:true
+ports = droid.input.external@equals:true->$droid_source_input_fmradio
+module= module-loopback@sink_input_properties='media.role=x-maemo%20media.name=fmradio-loopback'%20latency_msec=250%20reset_on_attach=true
+flags = refresh_always, module_unload_immediately
+
+[stream]
+property = media.name@equals:"fmradio-loopback"
+group    = player

--- a/sparse/etc/pulse/xpolicy.conf.d/usbaudio.conf.disabled
+++ b/sparse/etc/pulse/xpolicy.conf.d/usbaudio.conf.disabled
@@ -1,0 +1,19 @@
+# To enable USB-OTG audio add a file
+# sparse/etc/udev/rules.d/99-pulseaudio-ignore-builtin-card.rules with contents
+#
+# KERNEL=="<CARD-HERE>", SUBSYSTEM=="sound", ATTR{id}=="<DEVICE-ID-HERE>", ENV{PULSE_IGNORE}="1"
+#
+# where you can determine <CARD-HERE> (usually card0) and <DEVICE-ID-HERE> with
+# $ udevadm info -a /dev/snd/by-path/*
+#
+# and in sparse/etc/pulse/xpolicy.conf.d make a symlink from this file to usbaudio.conf
+
+[device]
+type  = usbaudio
+sink  = startswith:"alsa_output."
+flags = refresh_always
+
+[device]
+type  = usbmic
+source= startswith:"alsa_input."
+flags = refresh_always

--- a/sparse/var/lib/nemo-pulseaudio-parameters/modes/usbaudio/mainvolume
+++ b/sparse/var/lib/nemo-pulseaudio-parameters/modes/usbaudio/mainvolume
@@ -1,0 +1,1 @@
+../../algs/mainvolume/lineout


### PR DESCRIPTION
Devices that have hardware support for either should act as instructed in the config files. This way if the configuration changes no need to do other than update the droid-configs submodule.