### PR TITLE
Add lowi.conf symlink

### DIFF
--- a/sparse/etc/lowi.conf
+++ b/sparse/etc/lowi.conf
@@ -1,0 +1,1 @@
+/system/etc/lowi.conf


### PR DESCRIPTION
Such that lowi does not exit during powerup on those devices where it is necessary.