### PR TITLE
Add strace to porter-tools

### DIFF
--- a/patterns/common/sailfish-porter-tools.yaml
+++ b/patterns/common/sailfish-porter-tools.yaml
@@ -11,6 +11,7 @@ Requires:
 - openssh-server
 - vim-enhanced
 - zypper
+- strace
 
 # jolla-rnd-device will enable usb-moded even when UI is not yet
 # brought up (useful during development, available since update10)


### PR DESCRIPTION
strace is a common enough debugging tool, especially early on when you might not have things like Wifi working yet so installing it manually can be difficult