### PR TITLE
Use os-release instead of sailfish-release.

### DIFF
--- a/kickstart/pack_package-droid-updater
+++ b/kickstart/pack_package-droid-updater
@@ -2,7 +2,7 @@ pushd $IMG_OUT_DIR
 
 DEVICE=@DEVICE@
 
-VERSION_FILE=./sailfish-release
+VERSION_FILE=./os-release
 source $VERSION_FILE
 
 # Locate rootfs tar.bz2 archive.

--- a/kickstart/post_nochroot/hybris
+++ b/kickstart/post_nochroot/hybris
@@ -1,1 +1,1 @@
-cp $INSTALL_ROOT/etc/sailfish-release $IMG_OUT_DIR
+cp $INSTALL_ROOT/etc/os-release $IMG_OUT_DIR


### PR DESCRIPTION
[release] Use os-release instead of sailfish-release. Contributes to JB#40935

We should use the os-release everywhere instead of sailfish-release to
make sure that different identification can be used. os-release will
always be the link to the right identification file regardless of the
name of the actual *-release file.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>