### PR TITLE
Add SAILFISH_CUSTOMER to os-release.

### DIFF
--- a/kickstart/post_nochroot/hybris
+++ b/kickstart/post_nochroot/hybris
@@ -1,1 +1,8 @@
 cp $INSTALL_ROOT/etc/os-release $IMG_OUT_DIR
+ls -l $INSTALL_ROOT/usr/share/ssu/features.d/customer-*.ini &> /dev/null
+if [ "$?" == "0" ]; then
+  for CFILE in $(ls -1 $INSTALL_ROOT/usr/share/ssu/features.d/customer-*.ini); do
+     CUSTOMER_TMP+=${CUSTOMER_TMP:+ }$(grep -i "^name[ ]*=" $CFILE | sed 's/^.*=[ \t]*//')
+  done
+  echo "SAILFISH_CUSTOMER=\""$(echo ${CUSTOMER_TMP} | sed 's![/ ()]\+!_!g')"\"" >> $IMG_OUT_DIR/os-release
+fi


### PR DESCRIPTION
[ks] Add SAILFISH_CUSTOMER to os-release for image builds. Contributes to JB#41099

When there are multiple of customer images it is not clear by default
what the image contains. This commit adds SAILFISH_CUSTOMER to the
os-release for the image builds so that later in the %pack we can use
this value to add more information to the image name what is this image
about.

We could also add all the other features from /usr/share/ssu/features.d/
however before doing that we would need to rename those to match e.g.
feature-*.ini naming scheme. Also if we would add all those that could
mean that the filename lenght is starting to be too much, which it
already after this commit almost is. ;)

NOTE: After this it is still up to the device specific %pack to take
this part in use.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>