### PR TITLE
Relax systemCheck.d a bit on droid-hal-*

### DIFF
--- a/sparse/etc/zypp/systemCheck.d/ha.check
+++ b/sparse/etc/zypp/systemCheck.d/ha.check
@@ -1,5 +1,6 @@
-requires:droid-hal-@DEVICE@
 requires:droid-config-@DEVICE@
+requires:droid-hal
+requires:droid-hal-img-boot
 requires:droid-hal-version-@DEVICE@
 requires:libhybris-libEGL
 requires:libhybris-libGLESv2


### PR DESCRIPTION
[systemCheck.d] Relax droid-hal-*. Contributes to JB#41325

When sharing an adaptation we can not be too specific on certain
packages such as droid-hal-* but we should refer to the provides
packages.

In the end we should think if we could add Requires lines to the
droid-hal-version package and require mainly that in this ha.check file,
but that is for future. :)

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>