### PR TITLE
Split policy earpiece configuration.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -353,29 +353,6 @@ sink  = droid.output.media_latency@equals:"true"
 ports = droid.output.primary@equals:"true"->output-wired_headphone
 
 [device]
-type  = earpieceandtvout
-sink  = droid.output.primary@equals:"true"
-ports = droid.output.primary@equals:"true"->output-earpiece
-
-[device]
-type  = earpieceforcall
-sink  = droid.output.primary@equals:"true"
-ports = droid.output.primary@equals:"true"->output-earpiece
-flags = delayed_port_change
-delay = 200
-
-[device]
-type  = earpiece
-sink  = droid.output.primary@equals:"true"
-ports = droid.output.primary@equals:"true"->output-earpiece
-
-[device]
-type  = earpieceforalien
-sink  = droid.output.media_latency@equals:"true"
-ports = droid.output.primary@equals:"true"->output-earpiece
-flags = refresh_always
-
-[device]
 type   = microphone
 source = droid.input.builtin@equals:"true"
 ports  = droid.input.builtin@equals:"true"->$droid_source_input_microphone

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez4.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez4.conf
@@ -46,21 +46,6 @@ name    = equals:$droid_card
 profile = $droid_card_profile
 
 [card]
-type    = earpiece
-name    = equals:$droid_card
-profile = voicecall
-
-[card]
-type    = earpieceforcall
-name    = equals:$droid_card
-profile = voicecall
-
-[card]
-type    = earpieceforalien
-name    = equals:$droid_card
-profile = communication
-
-[card]
 type    = ihfforcall
 name    = equals:$droid_card
 profile = voicecall

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez4_earpiece.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez4_earpiece.conf
@@ -1,0 +1,14 @@
+[card]
+type    = earpiece
+name    = equals:$droid_card
+profile = voicecall
+
+[card]
+type    = earpieceforcall
+name    = equals:$droid_card
+profile = voicecall
+
+[card]
+type    = earpieceforalien
+name    = equals:$droid_card
+profile = communication

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
@@ -143,30 +143,6 @@ profile1 = off
 flags1   = disable_notify
 
 [card]
-type    = earpiece
-name0   = equals:$droid_card
-profile0= voicecall
-name1    = startswith:"bluez_card"
-profile1 = off
-flags1   = disable_notify
-
-[card]
-type    = earpieceforcall
-name0   = equals:$droid_card
-profile0= voicecall
-name1    = startswith:"bluez_card"
-profile1 = off
-flags1   = disable_notify
-
-[card]
-type    = earpieceforalien
-name0   = equals:$droid_card
-profile0= communication
-name1    = startswith:"bluez_card"
-profile1 = off
-flags1   = disable_notify
-
-[card]
 type    = ihfforcall
 name0   = equals:$droid_card
 profile0= voicecall

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez5_earpiece.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez5_earpiece.conf
@@ -1,0 +1,23 @@
+[card]
+type    = earpiece
+name0   = equals:$droid_card
+profile0= voicecall
+name1    = startswith:"bluez_card"
+profile1 = off
+flags1   = disable_notify
+
+[card]
+type    = earpieceforcall
+name0   = equals:$droid_card
+profile0= voicecall
+name1    = startswith:"bluez_card"
+profile1 = off
+flags1   = disable_notify
+
+[card]
+type    = earpieceforalien
+name0   = equals:$droid_card
+profile0= communication
+name1    = startswith:"bluez_card"
+profile1 = off
+flags1   = disable_notify

--- a/sparse/etc/pulse/xpolicy.conf.d/earpiece.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/earpiece.conf
@@ -1,0 +1,22 @@
+[device]
+type  = earpieceandtvout
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
+
+[device]
+type  = earpieceforcall
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
+flags = delayed_port_change
+delay = 200
+
+[device]
+type  = earpiece
+sink  = droid.output.primary@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
+
+[device]
+type  = earpieceforalien
+sink  = droid.output.media_latency@equals:"true"
+ports = droid.output.primary@equals:"true"->output-earpiece
+flags = refresh_always


### PR DESCRIPTION
There may be devices with voice modem but no earpiece connected. Split
earpiece configuration from the main xpolicy.conf so that with these
kind of devices earpiece route can be disabled by removing earpiece.conf
and bluez4_earpiece.conf or bluez5_earpiece.conf in delete_file_foo.list.
