### PR TITLE
Classify fmradio loopback source as player.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -539,10 +539,6 @@ group = internal
 name  = "input of source."
 group = internal
 
-[stream]
-property = media.role@equals:"abstract"
-group    = internal
-
 # For routing to sink.primaryandbluez
 [stream]
 property = media.name@startswith:"Simultaneous output on"

--- a/sparse/etc/pulse/xpolicy.conf.d/fmradio.conf.disabled
+++ b/sparse/etc/pulse/xpolicy.conf.d/fmradio.conf.disabled
@@ -14,7 +14,7 @@ flags = refresh_always
 type  = headphoneasfmradiolp
 source= droid.input.external@equals:true
 ports = droid.input.external@equals:true->$droid_source_input_fmradio
-module= module-loopback@sink_input_properties='media.role=x-maemo%20media.name=fmradio-loopback'%20latency_msec=250
+module= module-loopback@sink_input_properties='media.role=x-maemo%20media.name=fmradio-loopback'%20source_output_properties='media.name=fmradio-loopback-source'%20latency_msec=250
 flags = refresh_always, module_unload_immediately
 
 [device]
@@ -27,9 +27,13 @@ flags = refresh_always
 type  = headsetasfmradiolp
 source= droid.input.external@equals:true
 ports = droid.input.external@equals:true->$droid_source_input_fmradio
-module= module-loopback@sink_input_properties='media.role=x-maemo%20media.name=fmradio-loopback'%20latency_msec=250
+module= module-loopback@sink_input_properties='media.role=x-maemo%20media.name=fmradio-loopback'%20source_output_properties='media.name=fmradio-loopback-source'%20latency_msec=250
 flags = refresh_always, module_unload_immediately
 
 [stream]
 property = media.name@equals:"fmradio-loopback"
+group    = player
+
+[stream]
+property = media.name@equals:"fmradio-loopback-source"
 group    = player


### PR DESCRIPTION
Instead of classifying source output of module-loopback as internal
(meaning policy enforcement doesn't touch the source output at all)
classify the source output as player. This way when we have multiple
sources to choose from policy enforcement can connect the source output
to correct source.

Now when for example USB-audio device with recording capabilities is
connected when fmradio is enabled, module-loopback connects to the
first source it sees which may be the wrong one. With this change
policy enforcement has pointers to select the right source.