### PR TITLE
[configs] Adjust udev partition rules to match what android does. JB#41430, JB#41473

### DIFF
--- a/sparse/lib/udev/platform-device
+++ b/sparse/lib/udev/platform-device
@@ -1,5 +1,0 @@
-#!/bin/sh
-RESULT=`echo "$1" | sed "s|/devices/\([^/]*\)/\([^/]*\)/.*|\1/\2|g"| cut -d'/' -f1`
-
-echo ANDROID_BLOCK_DEVICE=$RESULT
-

--- a/sparse/lib/udev/rules.d/998-droid-system.rules
+++ b/sparse/lib/udev/rules.d/998-droid-system.rules
@@ -10,6 +10,50 @@ SUBSYSTEM=="misc", KERNEL=="log_radio", SYMLINK+="alog/radio"
 SUBSYSTEM=="misc", KERNEL=="log_system", SYMLINK+="alog/system"
 SUBSYSTEM=="misc", KERNEL=="log_main", SYMLINK+="alog/main"
 
-ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", IMPORT{program}="/bin/sh /lib/udev/platform-device $env{DEVPATH}", SYMLINK+="block/platform/$env{ANDROID_BLOCK_DEVICE}/by-name/$env{ID_PART_ENTRY_NAME}"
+# Partition symlinks, compatible with the android way of setting up the
+# symlinks.
 
-ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", IMPORT{program}="/bin/sh /lib/udev/platform-device $env{DEVPATH}", SYMLINK+="block/bootdevice/by-name/$env{ID_PART_ENTRY_NAME}"
+# Pass collected (see below) information down to lower levels.
+SUBSYSTEM=="?*", ENV{PLATFORM_FOLDER}=="", IMPORT{parent}="PLATFORM_FOLDER"
+SUBSYSTEM=="?*", ENV{PLATFORM_DEVICE}=="", IMPORT{parent}="PLATFORM_DEVICE"
+# Collect information about the platform devices:
+# /sys/devices/platform/FOLDER
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", ENV{PLATFORM_FOLDER}="$kernel"
+# /sys/devices/platform/FOLDER/DEVICE
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", ENV{PLATFORM_DEVICE}="$kernel"
+# /sys/devices/FOLDER
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", ENV{PLATFORM_FOLDER}="$kernel"
+# /sys/devices/FOLDER/DEVICE
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", ENV{PLATFORM_DEVICE}="$kernel"
+
+# This will set up the bootdevice symlink, given that androidboot.bootdevice
+# is set on the commandline. If it is not given on the cmdline, android-init
+# will create the bootdevice (if the paths are correct, which they now should
+# be). If android-init doesn't create the bootdevice symlink and there is no
+# androidboot.bootdevice on the cmdline, then the bootdevice symlink is not
+# required.
+IMPORT{cmdline}="bootdevice"
+# Unfortunately we cannot compare two variables, therefore use a workaround
+# with a file.
+ENV{bootdevice}!="", RUN+="/bin/touch /tmp/udev-$env{bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/ln -s /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice} /dev/block/bootdevice"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/ln -s /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice} /dev/block/bootdevice"
+# On certain devices the path is .../$PLATFORM_FOLDER/$PLATFORM_DEVICE/...,
+# but on others there is no $PLATFORM_DEVICE subdirectory, or in other words,
+# PLATFORM_FOLDER=platform device, PLATFORM_DEVICE=empty string. (1).
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/mkdir -p /dev/block/platform/$env{bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{bootdevice} /dev/block/bootdevice"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/mkdir -p /dev/block/platform/$env{bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{bootdevice} /dev/block/bootdevice"
+
+# Create the partition symlinks.
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", SYMLINK+="block/platform/$env{PLATFORM_FOLDER}/$env{PLATFORM_DEVICE}/by-name/$env{ID_PART_ENTRY_NAME}"
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", SYMLINK+="block/platform/$env{PLATFORM_FOLDER}/$env{PLATFORM_DEVICE}/by-num/p$env{ID_PART_ENTRY_NUMBER}"
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", SYMLINK+="block/platform/$env{PLATFORM_FOLDER}/$env{PLATFORM_DEVICE}/$name"
+
+# Backwards compatibility for old SailfishOS approach (might not be necessary)
+# NOTE: if the comment marked with (1) applies then this will not do anything.
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", SYMLINK+="block/platform/$env{PLATFORM_FOLDER}/by-name/$env{ID_PART_ENTRY_NAME}"
+


### PR DESCRIPTION
Change udev rules to fix /devices/dir1/dir2 platform device handling.
This also fixes the bootdevice symlink creation such that we don't need
special handling on some devices.
It also avoids the usage of scripts entirely, which means far less udev
processes are started during the boot process (currently >240), which improves
the boot up time.
This currently removes the /lib/udev/platform-device script, since it should
not be necessary anymore. Rules using that script will fail, but that is fine
since the bootdevice is now handled here. If someone uses this script they will
quickly notice that something has changed and that those obsolete rules need to
be removed.
This also fixes an issue with certain android daemons (one of which is
qseecomd), which on some devices expects that /dev/block/bootdevice is a
symlink to the /dev/block/platform/dir1/dir2 bootdevice entry.
In our previous implementation /dev/block/bootdevice contained symlinks to
/dev/block/platform/dir1/dir2/mmcblk* entries, now it is a symlink itself, as
expected by some android daemons.
Unfortunately we cannot do comparisions like ENV{X}==ENV{Y} or
ENV{X}=="$env{Y}", therefore the comparision with androidboot.bootdevice works
via a dummy file in /tmp.
