### PR TITLE
[boot] use nohup on droid-hal-init. JB#41779

### DIFF
--- a/sparse/usr/bin/droid/droid-hal-startup.sh
+++ b/sparse/usr/bin/droid/droid-hal-startup.sh
@@ -13,5 +13,8 @@ fi
 # Save systemd notify socket name to let droid-init-done.sh pick it up later
 echo $NOTIFY_SOCKET > /run/droid-hal/notify-socket-name
 
-exec /sbin/droid-hal-init
+# Use exec nohup since systemd may send SIGHUP, but droid-hal-init doesn't
+# handle it. This avoids having to modify android_system_core, which would
+# require different handling for every different android version.
+exec nohup /sbin/droid-hal-init
 


### PR DESCRIPTION
Use exec nohup since systemd may send SIGHUP, but droid-hal-init doesn't
handle it. This avoids having to modify android_system_core, which would
require different handling for every different android version.