### PR TITLE
[configs] Add yama.conf. Contributes to JB#41423

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -307,7 +307,7 @@ echo "%defattr(-,root,root,-)" > tmp/droid-config.files
 copy_files_from() {
   config_dir=$1
   if [ -d $config_dir ]; then
-    (cd $config_dir; find . \( -type f -or -type l \) -print ) | sed 's/^.//' >> tmp/droid-config.files
+    (cd $config_dir; find . \( -type f -o -type l \) -print ) | sed 's/^.//' >> tmp/droid-config.files
     cp -Rf $config_dir/* $RPM_BUILD_ROOT/
   fi
 }

--- a/sparse/etc/sysctl.d/yama.conf
+++ b/sparse/etc/sysctl.d/yama.conf
@@ -1,0 +1,1 @@
+kernel.yama.ptrace_scope = 2


### PR DESCRIPTION
Add yama.conf and set kernel.yama.ptrace_scope = 2 to prevent anyone but
allowed processes or root from ptracing. This will only affect devices with YAMA
LSM activated.