### PR TITLE
[configs] Lock filesystem mount whitelisting. Contributes to JB#44456

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/locks/udisks2-fs-mount-whitelist.txt
+++ b/sparse/etc/dconf/db/vendor.d/locks/udisks2-fs-mount-whitelist.txt
@@ -1,0 +1,1 @@
+/org/freedesktop/udisks2/filesystem/whitelist


### PR DESCRIPTION
This makes /org/freedesktop/udisks2/filesystem/whitelist
dconf key as non-writable key.