### PR TITLE
Protect rest of the filesystem from the droid-init.

### DIFF
--- a/sparse/lib/systemd/system/droid-hal-init.service
+++ b/sparse/lib/systemd/system/droid-hal-init.service
@@ -12,6 +12,9 @@ Conflicts=shutdown.target
 [Service]
 Type=notify
 NotifyAccess=all
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
 ExecStart=/bin/sh /usr/bin/droid/droid-hal-startup.sh
 ExecStop=/bin/sh /usr/bin/droid/droid-hal-shutdown.sh %c
 Restart=always


### PR DESCRIPTION
[systemd] Protect rest of the filesystem from the droid-init. JB#45315

Systemd provides sandboxing features that we could utilize to limit the
access of the processes started by droid-init. Here is a first attempt
to limit some of the access rights on device.

We can most likely limit it much further. Some more things to read at
https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Sandboxing

Eventually we should target to have e.g. ProtectSystem=strict, but before
doing that would need to know which files and/or directories the
droid-hal-init expects to have in rw mode.

I tested this setup on my XA2 and at least it boots and did not notice
any immediate fails.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>