### PR TITLE
[configs] Do not set LD_LIBRARY_PATH in droid-hal-startup.sh. JB#45601

### DIFF
--- a/sparse/usr/bin/droid/droid-hal-startup.sh
+++ b/sparse/usr/bin/droid/droid-hal-startup.sh
@@ -2,13 +2,7 @@
 cd /
 touch /dev/.coldboot_done
 
-if [ "$(uname -m | grep -o 64)" == "64" ]; then
-    # for 64 bit use the default LD_LIBRARY_PATH, otherwise we get conflicts.
-    export LD_LIBRARY_PATH=
-else
-    # for 32 bit, this is safe
-    export LD_LIBRARY_PATH=/usr/libexec/droid-hybris/system/lib/:/vendor/lib:/system/lib
-fi
+export LD_LIBRARY_PATH=
 
 # Save systemd notify socket name to let droid-init-done.sh pick it up later
 echo $NOTIFY_SOCKET > /run/droid-hal/notify-socket-name


### PR DESCRIPTION
Not needed anymore on most Android bases and causes mobile data issues on some devices.