### PR TITLE
After we have found our bootdevice, skip the rest.

### DIFF
--- a/sparse/lib/udev/rules.d/998-droid-system.rules
+++ b/sparse/lib/udev/rules.d/998-droid-system.rules
@@ -35,10 +35,13 @@ SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/de
 # be). If android-init doesn't create the bootdevice symlink and there is no
 # androidboot.bootdevice on the cmdline, then the bootdevice symlink is not
 # required.
+TEST=="/dev/block/bootdevice", GOTO="bootdevice_end"
+
 IMPORT{cmdline}="bootdevice"
 # Unfortunately we cannot compare two variables, therefore use a workaround
 # with a file.
-ENV{bootdevice}!="", RUN+="/bin/touch /tmp/udev-$env{bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", ENV{bootdevice}!="", RUN+="/bin/touch /tmp/udev-$env{bootdevice}"
+
 SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice}"
 SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/ln -s /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice} /dev/block/bootdevice"
 SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice}"
@@ -50,6 +53,8 @@ SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/de
 SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{bootdevice} /dev/block/bootdevice"
 SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/mkdir -p /dev/block/platform/$env{bootdevice}"
 SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{bootdevice} /dev/block/bootdevice"
+
+LABEL="bootdevice_end"
 
 # Create the partition symlinks.
 ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", SYMLINK+="block/platform/$env{PLATFORM_FOLDER}/$env{PLATFORM_DEVICE}/by-name/$env{ID_PART_ENTRY_NAME}"


### PR DESCRIPTION
[udev] Skip rest after finding boot device. Contributes to JB#45952

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>