### PR TITLE
[configs] Specify supported special number handlers. Contributes to JB#46077

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/locks/voicecall-special-number-handlers.txt
+++ b/sparse/etc/dconf/db/vendor.d/locks/voicecall-special-number-handlers.txt
@@ -1,0 +1,1 @@
+/desktop/jolla/specials/supported

--- a/sparse/etc/dconf/db/vendor.d/voicecall-special-number-handlers.txt
+++ b/sparse/etc/dconf/db/vendor.d/voicecall-special-number-handlers.txt
@@ -1,0 +1,2 @@
+[desktop/jolla/specials]
+supported='csd,'


### PR DESCRIPTION
Specify the csd application as a special number handler (dialer).
Prevent malicious applications from injecting themselves as special
number handlers.