### PR TITLE
Enable early init for droid-hal if needed

### DIFF
--- a/sparse/lib/systemd/system/droid-hal-init.service
+++ b/sparse/lib/systemd/system/droid-hal-init.service
@@ -15,6 +15,7 @@ NotifyAccess=all
 ProtectSystem=full
 ProtectHome=true
 PrivateTmp=true
+ExecStartPre=-/bin/sh /usr/bin/droid/droid-hal-early-init.sh
 ExecStart=/bin/sh /usr/bin/droid/droid-hal-startup.sh
 ExecStop=/bin/sh /usr/bin/droid/droid-hal-shutdown.sh %c
 Restart=always


### PR DESCRIPTION
Facilitates a possibility to launch commands tailored per-device just before the droid-hal-init starts.