### PR TITLE
Handle emergency_call context variable from policy.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -546,3 +546,8 @@ set-property = module-name@equals:module-policy-enforcement, property:"x-nemo.vo
 variable     = media_state
 value        = matches:"^[^t].*"
 set-property = module-name@equals:module-policy-enforcement, property:"x-nemo.media.state", value@copy-from-context
+
+[context-rule]
+variable     = emergency_call
+value        = matches:".*"
+set-property = module-name@equals:module-policy-enforcement, property:"x.emergency_call.state", value@copy-from-context


### PR DESCRIPTION
Context variable needs to be defined here so that the value is passed to
the relevant parts (pulseaudio-modules-nemo/mainvolume).
