### PR TITLE
Remove obsoleted sd-utils package from pattern.

### DIFF
--- a/patterns/templates/jolla-hw-adaptation-@DEVICE@.yaml
+++ b/patterns/templates/jolla-hw-adaptation-@DEVICE@.yaml
@@ -75,8 +75,5 @@ Requires:
 #- qt5-qtmultimedia-plugin-mediaservice-irisradio
 #- jolla-mediaplayer-radio
 
-# For devices with SD Card
-#- sd-utils
-
 Summary: Jolla HW Adaptation @DEVICE@
 


### PR DESCRIPTION
The replacement for sd-utils is udisk2 and it is dependency for
patterns-sailfish-mw meta package.