### PR TITLE
udev: fix firmware loading if the udev user loading fails.

### DIFF
--- a/sparse/usr/bin/droid/droid-load-firmware.sh
+++ b/sparse/usr/bin/droid/droid-load-firmware.sh
@@ -23,6 +23,7 @@ if [ -e /sys$DEVPATH/loading ]; then
     done
 
     log "Failed to find firmware $FIRMWARE for $DEVPATH"
+    echo "\-1" > /sys$DEVPATH/loading
     exit 1
 else
     log "Failed to find /sys$DEVPATH/loading, could not load $FIRMWARE."


### PR DESCRIPTION
[udev] fix firmware loading if the udev user loading fails. JB#43076

The kernel also needs to have a chance to be able to load the firmware.