### PR TITLE
[dhc] Add 212 keycode KEY_CAMERA as camera button

### DIFF
--- a/configs/droid.kmap
+++ b/configs/droid.kmap
@@ -22,3 +22,4 @@ keycode 226 = ToggleCallHangup
 keycode 256 = ToggleCallHangup
 keycode 528 = CameraFocus
 keycode 766 = Camera
+keycode 212 = Camera


### PR DESCRIPTION
My device is using KEY_CAMERA for camera button instead of KEY_CAMERA_SNAPSHOT. This change won't break anything but it might be helpful for other device that do this.