### PR TITLE
ks: Build rnd kickstart also on branch_devel level.

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -510,8 +510,8 @@ fi
   %endif
 %endif
 
-# build rnd kickstarts on devel level, release kickstarts on all other levels
-%if 0%{?qa_stage_devel:1}
+# build rnd kickstarts on devel and branch_devel level, release kickstarts on all other levels
+%if 0%{?qa_stage_devel:1} || 0%{?qa_stage_branch_devel:1}
   KS_LEVELS=true
 %else
   KS_LEVELS=false


### PR DESCRIPTION
[ks] Build rnd kickstart also on branch_devel level. Fixes JB#48212

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>