### PR TITLE
[configs] Figure out cgroup name in the script itself. Fixes JB#48226

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -78,6 +78,8 @@ BuildRequires: ssu-kickstart-configuration
 BuildRequires: pkgconfig(android-headers)
 BuildRequires: repomd-pattern-builder
 BuildRequires: qt5-qttools-kmap2qmap
+BuildRequires: sed
+Requires: sed
 Requires: droid-hal
 %if 0%{?community_adaptation:1}
 # because it provides one ssu feature, do:

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -32,10 +32,11 @@
 #    class_stop main
 #    class_stop core
 
-# Kill all processes that are in this same cgroup ($1) 
-[ -z "$1" ] && echo "Need cgroup path" && exit 1
-CGROUP=$1
-[ ! -f /sys/fs/cgroup/systemd/$CGROUP/cgroup.procs ] && echo "No such cgroup: $1" && exit 1
+# Kill all processes that are in this same cgroup.
+# Deducing the name of the service's cgroup based on the shutdown script's
+# cgroup name.
+CGROUP=$(cat /proc/self/cgroup | sed -r '/1:name=systemd:/!d;s|||;s|/control||')
+[ ! -f /sys/fs/cgroup/systemd/$CGROUP/cgroup.procs ] && echo "No such cgroup: $CGROUP" && exit 1
 
 get_pids() {
     # Get list of running pids in this cgroup


### PR DESCRIPTION
We can't rely on the command line argument anymore because systemd v233
has dropped "%c" specifier support. So we are constructing the name
of the service's cgroup based on the cgroup name of this script.

Signed-off-by: Igor Zhbanov <i.zhbanov@omprussia.ru>