### PR TITLE
aarch64: correct lookup path for all architectures

### DIFF
--- a/sparse/usr/share/environment/nemo/hybris.conf
+++ b/sparse/usr/share/environment/nemo/hybris.conf
@@ -1,2 +1,0 @@
-# Ensure that we can find hybris libs from any hybris-enabled binary
-HYBRIS_LD_LIBRARY_PATH=/usr/libexec/droid-hybris/system/lib:/vendor/lib:/system/lib

--- a/sparse/var/lib/environment/nemo/99-hybris.conf
+++ b/sparse/var/lib/environment/nemo/99-hybris.conf
@@ -1,2 +1,0 @@
-# Ensure that we can find hybris libs from any hybris-enabled binary
-HYBRIS_LD_LIBRARY_PATH=/usr/libexec/droid-hybris/system/lib:/vendor/lib:/system/lib


### PR DESCRIPTION
These files were introduced a long time ago, since then LD_LIBRARY_PATH
handling has improved in libhybris and android frameworks patches.

With those files removed, graphics apps load fine from ssh command-line on
64bit adaptations, as well as making pulseaudio not to crash on startup
when looking for libhardware.so in right places.

This has been tested not to break 32bit Sailfish OS adaptations.