### PR TITLE
[kickstart] Transfer variable root_lvm_size to external settings. Contributes to JB#50662

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -519,6 +519,12 @@ sed -e 's|@DEVICE@|%{rpm_device}|g' \
     >$RPM_BUILD_ROOT/%{_datadir}/ssu/features.d/adaptation-community.ini
 %endif
 
+%if 0%{!?lvm_root_size:1}
+%define lvm_root_size 2500
+%endif
+
+sed --in-place 's|@LVM_ROOT_PART_SIZE@|%{lvm_root_size}|' %{dcd_path}/kickstart/part/%{rpm_device}
+
 # Copy kickstart packs (for %%{rpm_device}-kickstart-configuration)
 mkdir -p $RPM_BUILD_ROOT/%{_datadir}/ssu/kickstart/pack/%{rpm_device}
 DEST_UPDATER=$RPM_BUILD_ROOT/%{_datadir}/ssu/kickstart/pack/%{rpm_device}/hybris


### PR DESCRIPTION
There are several at least two places where this variable can be configured in the kickstart file and here.
The configuration for this setting is more correct to install in one place and this droid-prjconf, or
used default value.