### PR TITLE
Add patterns-sailfish-core-device to ha.check.

### DIFF
--- a/sparse/etc/zypp/systemCheck.d/ha.check
+++ b/sparse/etc/zypp/systemCheck.d/ha.check
@@ -5,3 +5,4 @@ requires:droid-hal-version-@DEVICE@
 requires:libhybris-libEGL
 requires:libhybris-libGLESv2
 requires:libhybris-libwayland-egl
+requires:patterns-sailfish-core-device


### PR DESCRIPTION
Patterns-sailfish-core-device meta package should always be
installed on device as it will require the needed device packages.