### PR TITLE
[udev] Fix androidboot.bootdevice kernel parameter name. Contributes to JB#45921

### DIFF
--- a/sparse/lib/udev/rules.d/998-droid-system.rules
+++ b/sparse/lib/udev/rules.d/998-droid-system.rules
@@ -34,21 +34,21 @@ SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/de
 # be). If android-init doesn't create the bootdevice symlink and there is no
 # androidboot.bootdevice on the cmdline, then the bootdevice symlink is not
 # required.
-IMPORT{cmdline}="bootdevice"
+IMPORT{cmdline}="androidboot.bootdevice"
 # Unfortunately we cannot compare two variables, therefore use a workaround
 # with a file.
-ENV{bootdevice}!="", RUN+="/bin/touch /tmp/udev-$env{bootdevice}"
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice}"
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/ln -s /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice} /dev/block/bootdevice"
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice}"
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/ln -s /dev/block/platform/$env{PLATFORM_FOLDER}/$env{bootdevice} /dev/block/bootdevice"
+ENV{androidboot.bootdevice}!="", RUN+="/bin/touch /tmp/udev-$env{androidboot.bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{androidboot.bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*/*", DEVPATH=="/devices/platform/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/ln -s /dev/block/platform/$env{PLATFORM_FOLDER}/$env{androidboot.bootdevice} /dev/block/bootdevice"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/mkdir -p /dev/block/platform/$env{PLATFORM_FOLDER}/$env{androidboot.bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*/*", DEVPATH=="/devices/*/*", TEST=="/tmp/udev-$env{PLATFORM_DEVICE}", RUN+="/bin/ln -s /dev/block/platform/$env{PLATFORM_FOLDER}/$env{androidboot.bootdevice} /dev/block/bootdevice"
 # On certain devices the path is .../$PLATFORM_FOLDER/$PLATFORM_DEVICE/...,
 # but on others there is no $PLATFORM_DEVICE subdirectory, or in other words,
 # PLATFORM_FOLDER=platform device, PLATFORM_DEVICE=empty string. (1).
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/mkdir -p /dev/block/platform/$env{bootdevice}"
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{bootdevice} /dev/block/bootdevice"
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/mkdir -p /dev/block/platform/$env{bootdevice}"
-SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{bootdevice} /dev/block/bootdevice"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/mkdir -p /dev/block/platform/$env{androidboot.bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH=="/devices/platform/*", DEVPATH!="/devices/platform/*/*", DEVPATH=="/devices/platform/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{androidboot.bootdevice} /dev/block/bootdevice"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/mkdir -p /dev/block/platform/$env{androidboot.bootdevice}"
+SUBSYSTEM=="platform", KERNEL!="", DEVPATH!="/devices/platform/*", DEVPATH!="/devices/*/*", DEVPATH=="/devices/*", TEST=="/tmp/udev-$env{PLATFORM_FOLDER}", RUN+="/bin/ln -s /dev/block/platform/$env{androidboot.bootdevice} /dev/block/bootdevice"
 
 # Create the partition symlinks.
 ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", SYMLINK+="block/platform/$env{PLATFORM_FOLDER}/$env{PLATFORM_DEVICE}/by-name/$env{ID_PART_ENTRY_NAME}"


### PR DESCRIPTION
The 998-droid-system.rules file contain rules for creating symbolic links
such as /dev/block/bootdevice. These links depend on the kernel command line
parameter "androidboot.bootdevice".

Previously the rule file used "bootdevice" as a parameter name. It worked
because systemd-udevd from v225 simply used strstr() to match for
"bootdevice=" substring, while the new systemd-udevd is more strict.

So let's use the full parameter name in the rule file.

Signed-off-by: Igor Zhbanov <i.zhbanov@omprussia.ru>