### PR TITLE
patterns: do not create identically named RPMs

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -688,28 +688,6 @@ ln -s bluez5/bluetooth /etc/bluetooth   || :
 %defattr(644,root,root,-)
 %endif
 
-%package -n patterns-sailfish-device-porter-tools
-Summary: Sailfish OS Device Porter Tools
-Requires: jolla-developer-mode
-Requires: sailfishsilica-qt5-demos
-Requires: libhybris-tests
-
-Requires: busybox-static
-Requires: net-tools
-Requires: openssh-clients
-Requires: openssh-server
-Requires: vim-enhanced
-Requires: zypper
-Requires: strace
-
-# jolla-rnd-device will enable usb-moded even when UI is not yet
-# brought up (useful during development)
-Requires: jolla-rnd-device
-
-%description -n patterns-sailfish-device-porter-tools
-Pattern with packages for common debugging tools used by porters
-
-%files -n patterns-sailfish-device-porter-tools
 
 %package -n patterns-sailfish-device-configuration-common
 Summary: Jolla Configuration common

--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -689,7 +689,7 @@ ln -s bluez5/bluetooth /etc/bluetooth   || :
 %endif
 
 
-%package -n patterns-sailfish-device-configuration-common
+%package -n patterns-sailfish-device-configuration-common-%{rpm_device}
 Summary: Jolla Configuration common
 Requires: patterns-sailfish-applications
 Requires: patterns-sailfish-ui
@@ -697,8 +697,13 @@ Requires: patterns-sailfish-ui
 # Sailfish OS CSD tool for hardware testing
 # needs some configuration to get all features working
 Recommends: csd
+# All 3 requires above will be replaced with new meta-package
+# "patterns-sailfish-device-configuration-common" that will become available in
+# the next Sailfish OS release after 3.4.0
 
-%description -n patterns-sailfish-device-configuration-common
+%description -n patterns-sailfish-device-configuration-common-%{rpm_device}
 Pattern with packages for common HW configurations
 
-%files -n patterns-sailfish-device-configuration-common
+%files -n patterns-sailfish-device-configuration-common-%{rpm_device}
+
+

--- a/helpers/migrate_patterns.sh
+++ b/helpers/migrate_patterns.sh
@@ -32,7 +32,6 @@ function migrate {
   sed -i '/^Requires: patterns-sailfish-ui/d' $METAPKG_DIR/"$metaspec"
   sed -i '/^Requires: csd/d' $METAPKG_DIR/"$metaspec"
   sed -i 's/Requires: jolla-configuration-/Requires: patterns-sailfish-device-configuration-/g' $METAPKG_DIR/"$metaspec"
-  sed -i 's/Requires: sailfish-porter-tools/Requires: patterns-sailfish-device-porter-tools/g' $METAPKG_DIR/"$metaspec"
   sed -i "s/@ICON_RES@/%{icon_res}/" $METAPKG_DIR/"$metaspec"
 
   {
@@ -74,7 +73,19 @@ fi
 
 for pattern in "$PATTERNS_DIR"/*.yaml; do
   while IFS= read -r f; do
-    if ! (echo "$f" | grep -qE "^- pattern:\s*sailfish-porter-tools|^- pattern:\s*jolla-hw-adaptation-"); then
+    if (echo "$f" | grep -q "^- pattern:\s*sailfish-porter-tools"); then
+      echo "Please replace '- pattern:sailfish-porter-tools' with:"
+      echo "- patterns-sailfish-dev-tools"
+      echo "- patterns-sailfish-rnd"
+      echo "- libhybris-tests"
+      echo "- busybox-static"
+      echo "- openssh-server"
+      echo "- zypper"
+      echo
+      echo "and re-run this script"
+      exit 1
+    fi
+    if ! (echo "$f" | grep -q "^- pattern:\s*jolla-hw-adaptation-"); then
       echo "File $pattern contains patterns that cannot be migrated automatically. Aborting."
       exit 1
     fi

--- a/helpers/migrate_patterns.sh
+++ b/helpers/migrate_patterns.sh
@@ -27,7 +27,7 @@ function migrate {
   sed -i 's/- /Requires: /g' $METAPKG_DIR/"$metaspec"
   sed -i 's/pattern://g' $METAPKG_DIR/"$metaspec"
   sed -i 's/Requires: jolla-hw-adaptation-/Requires: patterns-sailfish-device-adaptation-/g' $METAPKG_DIR/"$metaspec"
-  sed -i "/^Requires: patterns-sailfish-device-adaptation-/i Requires: patterns-sailfish-device-configuration-common" $METAPKG_DIR/"$metaspec"
+  sed -i "/^Requires: patterns-sailfish-device-adaptation-/i Requires: patterns-sailfish-device-configuration-common-$device" $METAPKG_DIR/"$metaspec"
   sed -i '/^Requires: patterns-sailfish-applications/d' $METAPKG_DIR/"$metaspec"
   sed -i '/^Requires: patterns-sailfish-ui/d' $METAPKG_DIR/"$metaspec"
   sed -i '/^Requires: csd/d' $METAPKG_DIR/"$metaspec"

--- a/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
+++ b/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
@@ -1,6 +1,6 @@
 %package -n patterns-sailfish-device-configuration-@DEVICE@
 Summary: Jolla Configuration @DEVICE@
-Requires: patterns-sailfish-device-configuration-common
+Requires: patterns-sailfish-device-configuration-common-@DEVICE@
 Requires: patterns-sailfish-device-adaptation-@DEVICE@
 
 # For devices with cellular modem. Those without one, please comment out:

--- a/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
+++ b/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
@@ -5,8 +5,14 @@ Requires: patterns-sailfish-device-adaptation-@DEVICE@
 
 # For devices with cellular modem. Those without one, please comment out:
 Requires: patterns-sailfish-cellular-apps
+
 # Early stages of porting benefit from these:
-Requires: patterns-sailfish-device-porter-tools
+Requires: patterns-sailfish-rnd
+Requires: patterns-sailfish-dev-tools
+Requires: libhybris-tests
+Requires: busybox-static
+Requires: openssh-server
+Requires: zypper
 
 Requires: sailfish-content-graphics-z%{icon_res}
 


### PR DESCRIPTION
Otherwise will have multiple conflicting choices in RPM repositories with more than one device variant.
