### PR TITLE
Tweaked NFC related parts

### DIFF
--- a/patterns/templates/patterns-sailfish-device-adaptation-@DEVICE@.inc
+++ b/patterns/templates/patterns-sailfish-device-adaptation-@DEVICE@.inc
@@ -67,9 +67,12 @@ Requires: geoclue-provider-hybris
 #Requires: qt5-qtmultimedia-plugin-mediaservice-irisradio
 #Requires: jolla-mediaplayer-radio
 
-# NFC for devices using Android 8 or newer as base
+# NFC support
+# 1. binder plugin requires Android 8 or a newer base
+# 2. pn54x plugin talks directly to pn54x driver
+# These plugins are mutually exclusive, you need to pick one:
 #Requires: nfcd-binder-plugin
-#Requires: jolla-settings-system-nfc
+#Requires: nfcd-pn54x-plugin
 
 %description -n patterns-sailfish-device-adaptation-@DEVICE@
 Pattern with packages for @DEVICE@ HW Adaptation

--- a/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
+++ b/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
@@ -19,6 +19,11 @@ Requires: sailfish-content-graphics-z%{icon_res}
 # For multi-SIM devices
 #Requires: jolla-settings-networking-multisim
 
+# For devices which support NFC
+#Requires: jolla-settings-system-nfc
+#Requires: nfcd-dbuslog-plugin
+#Requires: nfcd-mce-plugin
+
 # Introduced starting Sailfish OS 2.0.4.x:
 # 3rd party accounts like Twitter, VK, cloud services, etc
 Requires: jolla-settings-accounts-extensions-3rd-party-all


### PR DESCRIPTION
1. Moved hardware independent NFC dependencies to configuration
2. Pulled in nfcd-dbuslog-plugin, it's not a built-in plugin anymore
3. Mentioned nfcd-pn54x-plugin as an NFC adaptation choice