### PR TITLE
[configs] Remove unsupported %s specificator. Contributes to JB#45921

### DIFF
--- a/sparse/usr/lib/systemd/system/droid-hal-init.service
+++ b/sparse/usr/lib/systemd/system/droid-hal-init.service
@@ -17,7 +17,7 @@ ProtectHome=true
 PrivateTmp=true
 ExecStartPre=-/bin/sh /usr/bin/droid/droid-hal-early-init.sh
 ExecStart=/bin/sh /usr/bin/droid/droid-hal-startup.sh
-ExecStop=/bin/sh /usr/bin/droid/droid-hal-shutdown.sh %c
+ExecStop=/bin/sh /usr/bin/droid/droid-hal-shutdown.sh
 Restart=always
 # Lets make sure we don't block minutes in case of errors.
 TimeoutSec=15


### PR DESCRIPTION
We have already fixed it in 7117c8392d088fa6f5fa429fa842b6fad6672803.
So no need to supply unused argument to droid-hal-shutdown.sh.

Signed-off-by: Igor Zhbanov <i.zhbanov@omprussia.ru>