### PR TITLE
configs: add support for meta packages

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -3,6 +3,9 @@
 #
 # community_adaptation: needs to be defined for community HW adaptations
 #
+# use_meta_package: define to use meta package jolla-configuration-%{rpm_device} with
+#                   all dependencies instead of patterns
+#
 # Device information:
 # device: should be the CM codename or the AOSP TARGET_PRODUCT
 # vendor: determine the droid-side directory used for ./device/<vendor>/<device>
@@ -582,10 +585,16 @@ fi
       while read line; do
         %gen_ks "$line"
         sed -i s/@VARIANT_NAME@/$line/g %{buildroot}/%{_datadir}/kickstarts/*$line*.ks
+        %if 0%{?use_meta_package:1}
+          sed -i "s/@Jolla Configuration /jolla-configuration-/g" %{buildroot}/%{_datadir}/kickstarts/*.ks
+        %endif
       done)
   fi
 %else
   %gen_ks %{rpm_device}
+  %if 0%{?use_meta_package:1}
+    sed -i "s/@Jolla Configuration %{rpm_device}/jolla-configuration-%{rpm_device}/g" %{buildroot}/%{_datadir}/kickstarts/*.ks
+  %endif
 %endif
 
 # Preinit plugins


### PR DESCRIPTION
Let's see if it goes through this time. From looking into the current "meta" package support, it looks to be missing ability for replacing @"Jolla Configuration DEVICE" with some package that would define installation. This PR adds this functionality.

It is a re-submission of https://github.com/mer-hybris/droid-hal-configs/pull/175 which has been closed for as other implementation was superseding it. Unfortunately, that other solution does not allow to use generated KS, but requires manual editing of.

An example of usage of meta packages is https://github.com/sailfishos-sony-tama/droid-config-sony-tama-pie . As soon as `use_meta_package` is specified in a config spec (as in https://github.com/sailfishos-sony-tama/droid-config-sony-tama-pie/blob/master/rpm/droid-config-h8216.spec), `jolla-configuration-...` SPEC is installed bringing with itself all the required dependencies.

The proposed solution works with OBS (https://build.merproject.org/project/show/nemo:devel:hw:sony:tama) and local builds.

As the example covers 6 devices, SPEC files are split into reused parts as much as possible. Current Requires section is at https://github.com/sailfishos-sony-tama/droid-config-sony-tama-pie/blob/master/jolla-configuration-tama.inc
