### PR TITLE
patterns: do not break the system when removing developer mode

### DIFF
--- a/helpers/migrate_patterns.sh
+++ b/helpers/migrate_patterns.sh
@@ -32,6 +32,7 @@ function migrate {
   sed -i '/^Requires: patterns-sailfish-ui/d' $METAPKG_DIR/"$metaspec"
   sed -i '/^Requires: csd/d' $METAPKG_DIR/"$metaspec"
   sed -i 's/Requires: jolla-configuration-/Requires: patterns-sailfish-device-configuration-/g' $METAPKG_DIR/"$metaspec"
+  sed -i 's/Requires: jolla-developer-mode$/Recommends: jolla-developer-mode/g' $METAPKG_DIR/"$metaspec"
   sed -i "s/@ICON_RES@/%{icon_res}/" $METAPKG_DIR/"$metaspec"
 
   {

--- a/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
+++ b/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
@@ -11,7 +11,7 @@ Requires: patterns-sailfish-rnd
 # dev-tools pattern will be fixed in the next release
 # for now we'll use its 'exploded' version:
 #Requires: patterns-sailfish-dev-tools
-Requires: jolla-developer-mode
+Recommends: jolla-developer-mode
 Requires: strace
 Requires: gdb
 Requires: gdb-gdbserver


### PR DESCRIPTION
When user disables developer mode via Settings, PackageKit removes `jolla-developer-mode` package.
If any patterns have hard dependencies on that, they get removed in turn resulting in broken system.