### PR TITLE
gbinder: Use API level 29 on Android 10 adaptations.

### DIFF
--- a/sparse-10/etc/gbinder.conf
+++ b/sparse-10/etc/gbinder.conf
@@ -1,0 +1,2 @@
+[General]
+ApiLevel = 29


### PR DESCRIPTION
[gbinder] Use API level 29 on Android 10 adaptations.