### PR TITLE
fingerprint: remove obsolete quirk.

### DIFF
--- a/sparse-10/etc/sailfish-fpd/50-settings.ini
+++ b/sparse-10/etc/sailfish-fpd/50-settings.ini
@@ -7,7 +7,6 @@ fphal_max_fingerprints_quirk    = 5
 
 mass_remove_single_notify_quirk = 0
 set_active_group_twice_quirk    = 0
-set_active_group_always_quirk   = 1
 skip_post_enroll_quirk          = 0
 skip_enumerate_quirk            = 0
 no_cancel_notification_quirk    = 0


### PR DESCRIPTION
The quirk has been reverted from the sailfish-fpd repository
and has been replaced with a proper fix for the issue.