### PR TITLE
bluez4: Require pulseaudio modules.

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -258,6 +258,8 @@ Conflicts: bluez5-configs
 Obsoletes: bluez-configs-sailfish
 Obsoletes: bluez-configs-mer
 
+Requires: pulseaudio-modules-bluez4
+
 %description bluez4
 %{summary}.
 


### PR DESCRIPTION
Starting from pulseaudio 14.2 version bluez4 modules has been separated to own package.