### PR TITLE
Drop reboot_warning_on_sim_remove

### DIFF
--- a/sparse-10/etc/dconf/db/vendor.d/lipstick-configs.txt
+++ b/sparse-10/etc/dconf/db/vendor.d/lipstick-configs.txt
@@ -1,6 +1,3 @@
-[desktop/lipstick-jolla-home]
-reboot_warning_on_sim_remove=true
-
 [desktop/lipstick-jolla-home/peekfilter]
 boundaryWidth=48
 pressDelay=800


### PR DESCRIPTION
This is not a generic Android 10 item. It should only be enabled for the hardware which doesn't support hot swap.