### PR TITLE
configs: Set default sink and source for PulseAudio.

### DIFF
--- a/sparse/etc/pulse/arm_droid_default.pa
+++ b/sparse/etc/pulse/arm_droid_default.pa
@@ -130,7 +130,8 @@ load-module module-systemd-login
 load-module module-dbus-protocol
 .endif
 
-### Move orphan streams to placeholder sinks or sources so that playback doesn't get
-### interrupted. Policy enforcement module then moves the streams to new appropriate
-### sinks or sources.
-load-module module-rescue-streams sink_name=sink.null source_name=source.null
+### Set default sink and source to sink.null and source.null, respectively. PulseAudio default
+### sink/source handling will move orphaned sink-inputs and source-outputs to default ones.
+### Policy enforcement module then moves the streams to new appropriate sinks or sources.
+set-default-sink sink.null
+set-default-source source.null


### PR DESCRIPTION
PulseAudio 14.0 changes to default sink/source routing made
module-rescue-streams obsolete. In addition PulseAudio will now
internally move orphan streams to default sink or source. We need to set
those now to the null variants so that we don't get audio bleed when for
example disconnecting Bluetooth headset (without the change stream would
be moved to non-null default sink, where some audio would be played
before media player reacts to resource policy's instructions to pause
playback).
    
After streams are moved to the null variants and playback has been
paused policy-enforcement module will move the streams to new
appropriate sinks or sources.