### PR TITLE
flash: Improve workaround.

### DIFF
--- a/sparse/boot/flash.sh
+++ b/sparse/boot/flash.sh
@@ -300,11 +300,16 @@ fi
 
 # Workaround for kickstart files until they are modified to not alter
 # flash.sh script directly.
-# If the valid product from flash-config.sh still contains the @ DEVICE @ placeholder,
+# If the valid product from flash-config.sh still contains @VALID_PRODUCTS@ placeholder,
 # assume this script is still being modified and set the product name here.
+# There are two variations of the modification, one uses DEVICE and other DEVICES
+# but both contain one or more of '-e "product_name"'
 for test_valid in "${VALID_PRODUCTS[@]}"; do
-    if [ "$(echo "$test_valid" | tr '@' '%')" == "%DEVICE%" ]; then
-        VALID_PRODUCTS=("$(echo "@DEVICE@" | cut -d' ' -f2)")
+    if [ "$test_valid" == "@VALID_PRODUCTS@" ]; then
+        VALID_PRODUCTS=($(printf %s "@DEVICES@" | sed 's/-e //g'))
+        if [ "${VALID_PRODUCTS[0]}" == '@DEVICES@' ]; then
+            VALID_PRODUCTS=($(printf %s "@DEVICE@" | sed 's/-e //g'))
+        fi
         break
     fi
 done


### PR DESCRIPTION
Old script has two variants, where either `@DEVICE@` or `@DEVICES@` is
replaced with the valid product name(s).
