### PR TITLE
patterns: remove sailfish-porter-tools

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -488,7 +488,6 @@ fi
 
 # patterns
 mkdir -p %{buildroot}/usr/share/package-groups/
-/usr/bin/repomd-pattern-builder.py --patternxml -p %{dcd_common}/patterns/common -o %{buildroot}/usr/share/package-groups/ --version=%{version} --release=%{release}
 /usr/bin/repomd-pattern-builder.py --patternxml -p %{dcd_path}/patterns/ -o %{buildroot}/usr/share/package-groups/ --version=%{version} --release=%{release}
 
 delete_patterns() {

--- a/helpers/migrate_patterns.sh
+++ b/helpers/migrate_patterns.sh
@@ -76,22 +76,7 @@ for pattern in "$PATTERNS_DIR"/*.yaml; do
   while IFS= read -r f; do
     if (echo "$f" | grep -q "^- pattern:\s*sailfish-porter-tools"); then
       echo "Please replace '- pattern:sailfish-porter-tools' with:"
-      echo "- patterns-sailfish-rnd"
-      echo "# dev-tools pattern will be fixed in the next release"
-      echo "# for now we'll use its 'exploded' version:"
-      echo "#- patterns-sailfish-dev-tools"
-      echo "- jolla-developer-mode"
-      echo "- strace"
-      echo "- gdb"
-      echo "- gdb-gdbserver"
-      echo "- vim-enhanced"
-      echo "- less"
-      echo "- valgrind"
-      echo "- lipstick-qt5-tools"
-      echo "- libhybris-tests"
-      echo "- busybox-static"
-      echo "- openssh-server"
-      echo "- zypper"
+      echo "- patterns-sailfish-device-tools"
       echo
       echo "and re-run this script"
       exit 1

--- a/patterns/common/sailfish-porter-tools.yaml
+++ b/patterns/common/sailfish-porter-tools.yaml
@@ -1,6 +1,0 @@
-Description: Pattern with packages for common debugging tools used by porters
-Name: sailfish-porter-tools
-Requires:
-- patterns-sailfish-device-porter-tools
-
-Summary: Sailfish OS Porter Tools

--- a/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
+++ b/patterns/templates/patterns-sailfish-device-configuration-@DEVICE@.inc
@@ -7,22 +7,7 @@ Requires: patterns-sailfish-device-adaptation-@DEVICE@
 Requires: patterns-sailfish-cellular-apps
 
 # Early stages of porting benefit from these:
-Requires: patterns-sailfish-rnd
-# dev-tools pattern will be fixed in the next release
-# for now we'll use its 'exploded' version:
-#Requires: patterns-sailfish-dev-tools
-Recommends: jolla-developer-mode
-Requires: strace
-Requires: gdb
-Requires: gdb-gdbserver
-Requires: vim-enhanced
-Requires: less
-Requires: valgrind
-Requires: lipstick-qt5-tools
-Requires: libhybris-tests
-Requires: busybox-static
-Requires: openssh-server
-Requires: zypper
+Requires: patterns-sailfish-device-tools
 
 Requires: sailfish-content-graphics-z%{icon_res}
 


### PR DESCRIPTION
Its replacement device-tools meta-package has been fixed since 4.0.1, let's implode it back.