### PR TITLE
configs: restart hwcomposer when lipstick exits.

### DIFF
--- a/sparse-10/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-3.conf
+++ b/sparse-10/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-3.conf
@@ -1,3 +1,4 @@
 [Service]
 # make unlock ui exit
 ExecStartPre=/usr/sbin/dummy_compositor
+ExecStopPost=/usr/bin/setprop ctl.restart vendor.hwcomposer-2-3


### PR DESCRIPTION
[configs] Restart hwcomposer when lipstick exists. JB#53672