### PR TITLE
bluez4: Fix HFP mode

### DIFF
--- a/sparse/etc/bluez4/bluetooth/audio.conf
+++ b/sparse/etc/bluez4/bluetooth/audio.conf
@@ -49,7 +49,7 @@ FastConnectable=false
 Disable=ConferenceCalling,InBandRingtone,EnhancedCallControl
 
 # Where to retrieve battery charge info from
-BatteryInfo=Statefs
+#BatteryInfo=Hal
 
 # Where to retrieve last dialed number from
 LastDialedNumber=/home/nemo/.cache/last-dialed


### PR DESCRIPTION
Statefs was removed from sailfish which cause telephony plugin initialization
failure. HFP connection fail with error: "Unable to accept HFP connection
since the telephony subsystem isn't initialized".

BatteryInfo=Hal is default value.