### PR TITLE
configs: Add /oem -> /vendor/oem symlink for all Android 10 based Sony devices

### DIFF
--- a/sparse-sony-10/oem
+++ b/sparse-sony-10/oem
@@ -1,0 +1,1 @@
+/vendor/oem


### PR DESCRIPTION
[configs] Add /oem -> /vendor/oem symlink for all Android 10 based Sony devices. JB#54540

The symlink is common for all Android 10 based Sony devices.