### PR TITLE
Use libngf-qt5-qtfeedback plugin

### DIFF
--- a/patterns/templates/patterns-sailfish-device-adaptation-@DEVICE@.inc
+++ b/patterns/templates/patterns-sailfish-device-adaptation-@DEVICE@.inc
@@ -21,7 +21,7 @@ Requires: hybris-libsensorfw-qt5
 
 # Vibra
 Requires: ngfd-plugin-native-vibrator
-Requires: qt5-feedback-haptics-native-vibrator
+Requires: libngf-qt5-qtfeedback
 
 # Needed for /dev/touchscreen symlink
 Requires: qt5-plugin-generic-evdev


### PR DESCRIPTION
patterns: Use libngf-qt5-qtfeedback plugin. This works better with sandboxing than native plugin.

Requires: https://github.com/sailfishos/libngf-qt/pull/1.