### PR TITLE
add route_audio flag to navigator group

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -134,7 +134,7 @@ source = droid.input.builtin@equals:"true"
 
 [group]
 name   = navigator
-flags  = set_sink, set_source
+flags  = set_sink, set_source, route_audio
 sink   = droid.output.media_latency@equals:"true"
 source = droid.input.builtin@equals:"true"
 


### PR DESCRIPTION
When navigation application is using navigator resource class (by setting NEMO_RESOURCE_CLASS_OVERRIDE environment variable), its voice instructions are played via phone speaker, even when bluetooth headphones are connected. By adding route_audio flag to xpolicy.conf, sound is routed via bluetooth headset properly. See Sailfish OS forum entry for more details: https://forum.sailfishos.org/t/navigation-instructions-doesnt-play-via-bluetooth-headphones-but-phone-speaker/7826