### PR TITLE
Tag jolla-camera record stream as camcorder.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -117,6 +117,10 @@ sink   = droid.output.media_latency@equals:"true"
 source = droid.input.builtin@equals:"true"
 
 [group]
+name   = videorecord
+flags  = route_audio
+
+[group]
 name   = videoeditor
 flags  = route_audio, limit_volume, cork_stream
 
@@ -510,6 +514,11 @@ group    = systemsound
 exe      = ngfd
 property = media.name@equals:"battery-event"
 group    = systemsound
+
+[stream]
+property = application.name@equals:"jolla-camera"
+group    = videorecord
+set-properties = droid.input.source='camcorder'
 
 [stream]
 exe   = telepathy-stream-engine


### PR DESCRIPTION
Use camcorder audio source for video recording in jolla-camera.
