### PR TITLE
Enable mouse input for lipstick homescreen

### DIFF
--- a/sparse-10/var/lib/environment/compositor/droid-hal-device.conf
+++ b/sparse-10/var/lib/environment/compositor/droid-hal-device.conf
@@ -1,5 +1,5 @@
 EGL_PLATFORM=hwcomposer
 QT_QPA_PLATFORM=hwcomposer
 
-LIPSTICK_OPTIONS="-plugin evdevtouch -plugin evdevkeyboard:keymap=/usr/share/qt5/keymaps/droid.qmap"
+LIPSTICK_OPTIONS="-plugin evdevtouch -plugin evdevmouse -plugin evdevkeyboard:keymap=/usr/share/qt5/keymaps/droid.qmap"
 


### PR DESCRIPTION
[configs] Enable mouse input for lipstick homescreen. Fixes JB#56095

Load evdev mouse plugin on lipstick start