### PR TITLE
sparse: Add a service for memory reclaim.

### DIFF
--- a/sparse/usr/bin/droid/droid-reclaim-memory.sh
+++ b/sparse/usr/bin/droid/droid-reclaim-memory.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+while [ "$(wc -l < /proc/swaps)" -lt 2 ]; do
+    sleep 1
+done
+
+TASKS=$(cat /sys/fs/cgroup/systemd/system.slice/*/cgroup.procs /sys/fs/cgroup/unified/system.slice/*/cgroup.procs /sys/fs/cgroup/system.slice/*/cgroup.procs)
+
+for task in $TASKS; do
+    echo "all" > /proc/"$task"/reclaim
+done
+
+DONE_FILE="/tmp/.droid-reclaim-memory-ran"
+
+if [ ! -f $DONE_FILE ]; then
+    # right after first login, no user apps are running yet
+    # reclaim also from the user session.
+    TASKS=$(cat /sys/fs/cgroup/systemd/user.slice/user-*.slice/*/cgroup.procs /sys/fs/cgroup/unified/user.slice/user-*.slice/*/cgroup.procs /sys/fs/cgroup/user.slice/user-*.slice/*/cgroup.procs)
+
+    for task in $TASKS; do
+        echo "all" > /proc/"$task"/reclaim
+    done
+
+    touch $DONE_FILE
+fi
+

--- a/sparse/usr/lib/systemd/system/droid-reclaim-memory.service
+++ b/sparse/usr/lib/systemd/system/droid-reclaim-memory.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Reclaim memory
+
+[Service]
+Type=oneshot
+After=init-done.service
+ExecStart=/usr/bin/droid/droid-reclaim-memory.sh
+DevicePolicy=strict
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=full
+

--- a/sparse/usr/lib/systemd/system/droid-reclaim-memory.timer
+++ b/sparse/usr/lib/systemd/system/droid-reclaim-memory.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Reclaim memory once per day and on boot
+ConditionPathExists=/proc/1/reclaim
+
+[Timer]
+OnStartupSec=1s
+OnUnitActiveSec=1d
+
+[Install]
+WantedBy=timers.target

--- a/sparse/usr/lib/systemd/system/timers.target.wants/droid-reclaim-memory.timer
+++ b/sparse/usr/lib/systemd/system/timers.target.wants/droid-reclaim-memory.timer
@@ -1,0 +1,1 @@
+../droid-reclaim-memory.timer


### PR DESCRIPTION
Perform a memory reclaim right after boot for all services
and once per day for system services.
The rationale is that android does a similar thing when use_compaction
is enabled. The idea is that memory that is unlikely to be needed again
will be put to swap. Of course we cannot know which memory will be
reused again but we let the kernel decide what to put back to RAM when
needed.

[sparse] Add a service for memory reclaim. JB#57321