### PR TITLE
sparse: Disable update_verifier for ports starting from Android 10

### DIFF
--- a/sparse-10/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
+++ b/sparse-10/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
@@ -27,3 +27,7 @@ service bootanim /system/bin/bootanimation_HYBRIS_DISABLED
 service vendor.usb-hal-1-0 /vendor/bin/hw/android.hardware.usb@1.0-service_HYBRIS_DISABLED
 
 service vendor.vibrator-1-0 /vendor/bin/hw/android.hardware.vibrator@1.0-service_HYBRIS_DISABLED
+
+service update_verifier_nonencrypted /system/bin/update_verifier_HYBRIS_DISABLED nonencrypted
+
+service update_verifier /system/bin/update_verifier_HYBRIS_DISABLED ${vold.decrypt}

--- a/sparse-11/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
+++ b/sparse-11/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
@@ -27,3 +27,7 @@ service bootanim /system/bin/bootanimation_HYBRIS_DISABLED
 service vendor.usb-hal-1-2 /vendor/bin/hw/android.hardware.usb@1.2-service_HYBRIS_DISABLED
 
 service vendor.vibrator-1-0 /vendor/bin/hw/android.hardware.vibrator@1.0-service_HYBRIS_DISABLED
+
+service update_verifier_nonencrypted /system/bin/update_verifier_HYBRIS_DISABLED nonencrypted
+
+service update_verifier /system/bin/update_verifier_HYBRIS_DISABLED ${vold.decrypt}


### PR DESCRIPTION
update_verifier tries to verify Android updates which doesn't make
sense in the case of it running as droid-system.
In our case it will likely fail and trigger a reboot, this will show
up in the symptom of a boot loop.