### PR TITLE
Add /lib/firmware to search path

### DIFF
--- a/sparse/usr/bin/droid/droid-load-firmware.sh
+++ b/sparse/usr/bin/droid/droid-load-firmware.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-FIRMWARE_FOLDERS="/system/etc/firmware/ /odm/firmware/ /vendor/firmware/ /firmware/image/ /vendor/firmware_mnt/image/"
+FIRMWARE_FOLDERS="/system/etc/firmware/ /odm/firmware/ /vendor/firmware/ /firmware/image/ /vendor/firmware_mnt/image/ /lib/firmware"
 
 log() {
     logger -p daemon.info -t firmware "$@"


### PR DESCRIPTION
In early boot, the other locations may not be mounted, so its useful to also search a path on the root filesystem