### PR TITLE
configs: Add compositor switch guards for standalone qt uis

### DIFF
--- a/sparse/usr/lib/systemd/user/jolla-actdead-charging.service.d/50-compositor.conf
+++ b/sparse/usr/lib/systemd/user/jolla-actdead-charging.service.d/50-compositor.conf
@@ -1,0 +1,4 @@
+[Service]
+# All devices: Make previous UI exit
+# When applicable: Have freshly started android hwc available
+ExecStartPre=/usr/sbin/dummy_compositor --hwc-restart --exit-on-enable

--- a/sparse/usr/lib/systemd/user/jolla-startupwizard-pre-user-session.service.d/50-compositor.conf
+++ b/sparse/usr/lib/systemd/user/jolla-startupwizard-pre-user-session.service.d/50-compositor.conf
@@ -1,0 +1,4 @@
+[Service]
+# All devices: Make previous UI exit
+# When applicable: Have freshly started android hwc available
+ExecStartPre=/usr/sbin/dummy_compositor --hwc-restart --exit-on-enable

--- a/sparse/usr/lib/systemd/user/lipstick.service.d/50-compositor.conf
+++ b/sparse/usr/lib/systemd/user/lipstick.service.d/50-compositor.conf
@@ -1,0 +1,4 @@
+[Service]
+# All devices: Make previous UI exit
+# When applicable: Have freshly started android hwc available
+ExecStartPre=/usr/sbin/dummy_compositor --hwc-restart --exit-on-enable


### PR DESCRIPTION
Qt gui applications can't delay graphics stack initialization. When such application needs direct access to display, we need to use dummy_compositor instance as a guard to perform display ownership transfer before starting the actual application binary.

While at it we can also signal that android hw composer service should be available. Whether this causes any actions depends on device specific mce configuration.

[configs] Add compositor switch guards for standalone qt uis. JB#59917