### PR TITLE
sparse: Fix incorrect After in droid-reclaim-memory.service

### DIFF
--- a/sparse/usr/lib/systemd/system/droid-reclaim-memory.service
+++ b/sparse/usr/lib/systemd/system/droid-reclaim-memory.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Reclaim memory
+After=init-done.service
 
 [Service]
 Type=oneshot
-After=init-done.service
 ExecStart=/usr/bin/droid/droid-reclaim-memory.sh
 DevicePolicy=strict
 NoNewPrivileges=yes


### PR DESCRIPTION
[sparse] Fix incorrect After in droid-reclaim-memory. JB#59939