### PR TITLE
Default to single output with twin outputs.

### DIFF
--- a/sparse/etc/pulse/xpolicy.conf
+++ b/sparse/etc/pulse/xpolicy.conf
@@ -34,6 +34,11 @@ droid_source_input_fmradio = input-fm_tuner
 droid_sink_port_change_delay = delayed_port_change
 sink_class_voip = droid.output.media_latency
 delay_time = 150
+# default to single output, if you know your device can support simultaneous
+# output change these in xvars.conf.
+twin_speaker_headset = output-speaker
+twin_speaker_headphone = output-speaker
+twin_speaker_lineout = output-speaker
 # cards and profiles
 droid_card = droid_card.primary
 droid_card_profile = default
@@ -191,7 +196,7 @@ sink = startswith:"bluez_sink"
 [device]
 type  = ihfandheadset
 sink  = droid.output.media_latency@equals:"true"
-ports = droid.output.primary@equals:"true"->output-speaker+wired_headphone
+ports = droid.output.primary@equals:"true"->$twin_speaker_headset
 flags = $droid_sink_port_change_delay
 delay = $delay_time
 
@@ -203,14 +208,14 @@ ports = droid.input.external@equals:"true"->input-wired_headset
 [device]
 type  = ihfandheadphone
 sink  = droid.output.media_latency@equals:"true"
-ports = droid.output.primary@equals:"true"->output-speaker+wired_headphone
+ports = droid.output.primary@equals:"true"->$twin_speaker_headphone
 flags = $droid_sink_port_change_delay
 delay = $delay_time
 
 [device]
 type  = ihfandlineout
 sink  = droid.output.media_latency@equals:"true"
-ports = droid.output.primary@equals:"true"->output-speaker+wired_headphone
+ports = droid.output.primary@equals:"true"->$twin_speaker_lineout
 flags = $droid_sink_port_change_delay
 delay = $delay_time
 


### PR DESCRIPTION
Most Android devices only support single output properly, and when old implementation of pulseaudio-modules-droid was split to legacy-jb2q, the new implementation dropped the feature altogether.

Also since we cannot have separate volume for wired output and speaker with these modes, we would need to attenuate the volume anyway so that we don't play the audio too loud if user has headset on.

In conclusion, at least with Android adaptations we should only use single output route when dealing with wired accessories.
