### PR TITLE
flash-partition: Support for checking /sys/firmware/devicetree/base/model

### DIFF
--- a/sparse/usr/sbin/flash-partition
+++ b/sparse/usr/sbin/flash-partition
@@ -77,7 +77,9 @@ on_device()
                         return 1
                 fi
         done
-        if cat /proc/cpuinfo | grep "$CPUCHECK_STRING" > /dev/null; then
+        if grep -q "$CPUCHECK_STRING" /proc/cpuinfo > /dev/null; then
+                return 0
+        elif grep -q "$CPUCHECK_STRING" /sys/firmware/devicetree/base/model > /dev/null; then
                 return 0
         else
                 return 1


### PR DESCRIPTION
Some newer devices don't have platform information in /proc/cpuinfo so use /sys/firmware/devicetree/base/model as optional place for checking that we are installing correct packages.

[flash-partition] Support for checking /sys/firmware/devicetree/base/model