### PR TITLE
Adjust pixel ratio comment text

### DIFF
--- a/droid-config-@DEVICE@.spec.template
+++ b/droid-config-@DEVICE@.spec.template
@@ -10,12 +10,9 @@
 # Community HW adaptations need this
 %define community_adaptation 1
 
-# Sailfish OS is considered to-scale, if in the App Grid you get 4-in-a-row icons,
-# and 2-in-a-row or 3-in-a-row app covers in the Home Screen, depending on
-# how many apps are open.
-# For 4-5.5" device screen sizes of 16:9 ratio, use this formula (hold portrait):
-# pixel_ratio = 4.5/DiagonalDisplaySizeInches * HorizontalDisplayResolution/540
-# Other screen sizes and ratios will require more trial-and-error.
+# Pixel ratio 1.0 was originally jolla phone with 245ppi, and the devices
+# should roughly have their ppi compared to that. Large displays can use
+# bigger ratio if seen fit. Values are with 0.25 increments.
 %define pixel_ratio 1.0
 
 %include droid-configs-device/droid-configs.inc


### PR DESCRIPTION
Suggest comparing pixels per inch rather than amount of launchers etc. The app cover sizes are calculated at runtime and it's not wrong to have 5 launchers on per row on bigger displays.