### PR TITLE
sparse: Allow input group to access selected paths in LED sysfs

### DIFF
--- a/sparse/lib/udev/rules.d/998-droid-system.rules
+++ b/sparse/lib/udev/rules.d/998-droid-system.rules
@@ -12,6 +12,11 @@ SUBSYSTEM=="misc", KERNEL=="log_main", SYMLINK+="alog/main"
 # Video device symlinks needed for video codecs
 SUBSYSTEM=="video4linux", KERNEL=="video[0-9]*", ATTRS{link_name}!="", SYMLINK+="video/%s{link_name}"
 
+# LED subsystem permissions, mainly relevant for vibrator
+SUBSYSTEM=="leds", ACTION=="add|change", RUN+="/bin/sh -c '/usr/bin/chown system:input /sys%p/activate && /usr/bin/chmod -R 664 /sys%p/activate'"
+SUBSYSTEM=="leds", ACTION=="add|change", RUN+="/bin/sh -c '/usr/bin/chown system:input /sys%p/duration && /usr/bin/chmod -R 664 /sys%p/duration'"
+SUBSYSTEM=="leds", ACTION=="add|change", RUN+="/bin/sh -c '/usr/bin/chown system:input /sys%p/state && /usr/bin/chmod -R 664 /sys%p/state'"
+
 # Partition symlinks, compatible with the android way of setting up the
 # symlinks.
 


### PR DESCRIPTION
Needed for vibrators which use LED interface to be accessed by ngfd.