### PR TITLE
Fix droid-hal-shutdown cleanup, ignore self from being terminated

### DIFF
--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -39,9 +39,9 @@ CGROUP=$(sed -r '/1:name=systemd:/!d;s|||;s|/control||' < /proc/self/cgroup)
 [ ! -f "/sys/fs/cgroup/systemd/$CGROUP/cgroup.procs" ] && echo "No such cgroup: $CGROUP" && exit 1
 
 get_pids() {
-    # Get list of running pids in this cgroup
+    # Get list of running pids in this cgroup, excluding this script
     # return list $PIDS and $NUM_PIDS
-    PIDS=$(cat /sys/fs/cgroup/systemd/$CGROUP/cgroup.procs)
+    PIDS=$(grep -Ev "\b$$\b" "/sys/fs/cgroup/systemd/$CGROUP/cgroup.procs")
     NUM_PIDS=$(echo "$PIDS" | wc -w)
     echo "Android service PIDs remaining: $NUM_PIDS"
 }

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -35,7 +35,7 @@
 # Kill all processes that are in this same cgroup.
 # Deducing the name of the service's cgroup based on the shutdown script's
 # cgroup name.
-CGROUP=$(cat /proc/self/cgroup | sed -r '/1:name=systemd:/!d;s|||;s|/control||')
+CGROUP=$(sed -r '/1:name=systemd:/!d;s|||;s|/control||' < /proc/self/cgroup)
 [ ! -f /sys/fs/cgroup/systemd/$CGROUP/cgroup.procs ] && echo "No such cgroup: $CGROUP" && exit 1
 
 get_pids() {

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -57,7 +57,7 @@ PREV_NUM_PIDS=$NUM_PIDS
 # We don't use it, but some init scripts watch for it as a signal to shut other things down
 /usr/bin/setprop sys.shutdown.requested 1
 
-echo "Shutting down droid-hal-init services"
+echo "Shutting down droid-hal-init services..."
 /usr/bin/setprop hybris.shutdown 1
 
 sleep 1
@@ -79,17 +79,17 @@ while [ $NUM_PIDS -gt 1 ] && [ $WAIT -lt $MAX_WAIT ]; do
     get_pids
 done
 
-echo "Killing droid-hal-init"
+echo "Killing droid-hal-init..."
 killall droid-hal-init
 
 get_pids
 if [ $NUM_PIDS -gt 0 ]; then
-    echo "Terminating processes hybris.shutdown missed"
+    echo "Terminating remaining processes after hybris.shutdown..."
     kill -TERM $PIDS
     sleep 1
     get_pids
     if [ $NUM_PIDS -gt 0 ]; then
-        echo "Killing processes hybris.shutdown missed"
+        echo "Killing remaining processes after hybris.shutdown..."
         kill -KILL $PIDS
     fi
 fi

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -36,7 +36,10 @@
 # Deducing the name of the service's cgroup based on the shutdown script's
 # cgroup name.
 CGROUP=$(sed -r '/1:name=systemd:/!d;s|||;s|/control||' < /proc/self/cgroup)
-[ ! -f "/sys/fs/cgroup/systemd/$CGROUP/cgroup.procs" ] && echo "No such cgroup: $CGROUP" && exit 1
+if [ ! -f "/sys/fs/cgroup/systemd/$CGROUP/cgroup.procs" ]; then
+    echo "No such cgroup: $CGROUP"
+    exit 1
+fi
 
 get_pids() {
     # Get list of running pids in this cgroup, excluding this script

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -79,16 +79,18 @@ done
 echo "Killing droid-hal-init"
 killall droid-hal-init
 
-echo "Killing processes hybris.shutdown missed"
 get_pids
 if [ $NUM_PIDS -gt 0 ]; then
-    killall $PIDS
+    echo "Terminating processes hybris.shutdown missed"
+    kill -TERM $PIDS
     sleep 1
     get_pids
     if [ $NUM_PIDS -gt 0 ]; then
-        killall -s 9 $PIDS
+        echo "Killing processes hybris.shutdown missed"
+        kill -KILL $PIDS
     fi
 fi
 
+get_pids
 exit 0
 

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -36,14 +36,14 @@
 # Deducing the name of the service's cgroup based on the shutdown script's
 # cgroup name.
 CGROUP=$(sed -r '/1:name=systemd:/!d;s|||;s|/control||' < /proc/self/cgroup)
-[ ! -f /sys/fs/cgroup/systemd/$CGROUP/cgroup.procs ] && echo "No such cgroup: $CGROUP" && exit 1
+[ ! -f "/sys/fs/cgroup/systemd/$CGROUP/cgroup.procs" ] && echo "No such cgroup: $CGROUP" && exit 1
 
 get_pids() {
     # Get list of running pids in this cgroup
     # return list $PIDS and $NUM_PIDS
     PIDS=$(cat /sys/fs/cgroup/systemd/$CGROUP/cgroup.procs)
-    NUM_PIDS=$(echo $PIDS | wc -w)
-    echo Android service PIDs remaining: $NUM_PIDS
+    NUM_PIDS=$(echo "$PIDS" | wc -w)
+    echo "Android service PIDs remaining: $NUM_PIDS"
 }
 
 # ============== main() ===============
@@ -54,7 +54,7 @@ PREV_NUM_PIDS=$NUM_PIDS
 # We don't use it, but some init scripts watch for it as a signal to shut other things down
 /usr/bin/setprop sys.shutdown.requested 1
 
-echo Shutting down droid-hal-init services
+echo "Shutting down droid-hal-init services"
 /usr/bin/setprop hybris.shutdown 1
 
 sleep 1
@@ -69,17 +69,17 @@ while [ $NUM_PIDS -gt 1 -a $WAIT -lt $MAX_WAIT ]; do
         # Wait a little bit more
         sleep 1
      else
-        # Number of pids is not gettting smaller
+        # Number of pids is not getting smaller
         break
     fi
     PREV_NUM_PIDS=$NUM_PIDS
     get_pids
 done
 
-echo Killing droid-hal-init
+echo "Killing droid-hal-init"
 killall droid-hal-init
 
-echo Killing processes hybris.shutdown missed
+echo "Killing processes hybris.shutdown missed"
 get_pids
 if [ $NUM_PIDS -gt 0 ]; then
     killall $PIDS

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -66,7 +66,7 @@ get_pids
 MAX_WAIT=5
 # -gt 1 because droid-hal-init is also in this cgroup
 while [ $NUM_PIDS -gt 1 ] && [ $WAIT -lt $MAX_WAIT ]; do
-    let WAIT=$WAIT+1
+    WAIT=$((WAIT+1))
     if [ $NUM_PIDS -lt $PREV_NUM_PIDS ]; then
         # Number of running processes is getting smaller
         # Wait a little bit more

--- a/sparse/usr/bin/droid/droid-hal-shutdown.sh
+++ b/sparse/usr/bin/droid/droid-hal-shutdown.sh
@@ -62,7 +62,7 @@ WAIT=1
 get_pids
 MAX_WAIT=5
 # -gt 1 because droid-hal-init is also in this cgroup
-while [ $NUM_PIDS -gt 1 -a $WAIT -lt $MAX_WAIT ]; do
+while [ $NUM_PIDS -gt 1 ] && [ $WAIT -lt $MAX_WAIT ]; do
     let WAIT=$WAIT+1
     if [ $NUM_PIDS -lt $PREV_NUM_PIDS ]; then
         # Number of running processes is getting smaller


### PR DESCRIPTION
- `killall` wants a list of process names instead of pids, so use `kill` instead
- Prevent the script from terminating itself by excluding its own pid
- Make logging a bit more precise, add the final process count printout
- Quote some strings and fix a typo in a comment
- Some adjustments in commands and conditions (by Shellcheck)

Shellcheck is still not quite happy, but all the remaining nags are ignoreable (~~BusyBox supports `let` expressions~~, all unquoted variables are integers or lists of integers). (Running `shellcheck -s busybox script.sh` should give better results, but it does not.)