### PR TITLE
configs: remove Requires: for bluez5-libs

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -238,7 +238,6 @@ Summary: %{rpm_device} packages for BlueZ 5
 Provides: %{rpm_device}-bluez-configs
 
 Requires: bluez5
-Requires: bluez5-libs
 Requires: bluez5-obexd
 Requires: kf5bluezqt-bluez5
 


### PR DESCRIPTION
Seems to be more of a legacy thing with nothing really needing it. What I gather it shouldn't be needed for generic bluetooth support.

[configs] remove Requires: for bluez5-libs. JB#37903