### PR TITLE
configs: Use separate profile for bluetooth HFP.

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -175,7 +175,7 @@ Provides:   droid-config-preinit-plugins
 %package pulseaudio-settings
 Summary:    PulseAudio settings for %{rpm_device} hw
 Provides:   droid-config-pulseaudio-settings
-Requires:   pulseaudio >= 11.1+git4
+Requires:   pulseaudio >= 15.0
 Requires:   pulseaudio-modules-nemo-parameters >= 11.1.24
 Requires:   pulseaudio-modules-nemo-stream-restore >= 11.1.24
 Requires:   pulseaudio-modules-nemo-mainvolume >= 11.1.24

--- a/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
+++ b/sparse/etc/pulse/xpolicy.conf.d/bluez5.conf
@@ -50,7 +50,7 @@ flags1   = disable_notify
 [card]
 type    = bthfp
 name0    = startswith:"bluez_card"
-profile0 = headset_head_unit
+profile0 = handsfree_head_unit
 name1    = equals:$card
 profile1 = $card_profile
 flags1   = disable_notify
@@ -58,7 +58,7 @@ flags1   = disable_notify
 [card]
 type    = bthfpforcall
 name0    = startswith:"bluez_card"
-profile0 = headset_head_unit
+profile0 = handsfree_head_unit
 name1    = equals:$card
 profile1 = voicecall
 flags1   = disable_notify
@@ -66,7 +66,7 @@ flags1   = disable_notify
 [card]
 type    = bthfpforalien
 name0    = startswith:"bluez_card"
-profile0 = headset_head_unit
+profile0 = handsfree_head_unit
 name1    = equals:$card
 profile1 = communication
 flags1   = disable_notify


### PR DESCRIPTION
Required with pulseaudio 15 and newer.