### PR TITLE
Avoid terminating droid-hal-init processes twice. JB#64557

### DIFF
--- a/sparse/usr/lib/systemd/system/droid-hal-init.service
+++ b/sparse/usr/lib/systemd/system/droid-hal-init.service
@@ -17,6 +17,9 @@ ProtectHome=true
 PrivateTmp=true
 ExecStartPre=-/bin/sh /usr/bin/droid/droid-hal-early-init.sh
 ExecStart=/bin/sh /usr/bin/droid/droid-hal-startup.sh
+# Since droid-hal-shutdown.sh effectively kills the cgroup processes (as well as it's possible),
+# systemd can safely skip trying to kill any stubborn processes the second time, causing unncessary delay.
+KillMode=none
 ExecStop=/bin/sh /usr/bin/droid/droid-hal-shutdown.sh
 Restart=always
 # Lets make sure we don't block minutes in case of errors.


### PR DESCRIPTION
droid-hal-shutdown.sh script already ends all processes that are cooperative enough to actually exit, so any remaining processes can just be ignored rather safely. Since system is going into shutdown anyway, the processes escaping lifetime control shouldn't be an issue.

Systemd has its own terminate-wait-kill-wait cycle after the ExecStop script returns if processes remain, and in this case it seems we can simply skip it. This can shorten the device shutdown time noticeably.