### PR TITLE
Use blkid to lookup partition by label

### DIFF
--- a/sparse/usr/sbin/flash-partition
+++ b/sparse/usr/sbin/flash-partition
@@ -46,12 +46,15 @@ if [ -z "$CPUCHECK_STRING" ]; then
   exit 1
 fi
 
-if [[ -z "$PART_1" || -z "$PART_REAL_1" || -z "$PART_I" ]]; then
+DEVICE=
+USE_BLKID=0
+if [[ -z "$PART_I" ]]; then
+  USE_BLKID=1
+elif [[ -z "$PART_1" || -z "$PART_REAL_1" ]]; then
   echo "At least one partition needs to be defined variables PART_1, PART_REAL_1 and PART_I."
   exit 1
 fi
 
-DEVDIR="/dev"
 
 print_help()
 {
@@ -62,21 +65,11 @@ print_help()
         echo "  Usage:"
         echo "    $0 <partition_label> <image_file> <optional_extra_arguments>"
         echo ""
-        echo "  Allowed partition labels:"
-        for I in ${PART_I}; do
-                eval echo "    \$PART_$I"
-        done
 }
 
 # Test if we are running on device
 on_device()
 {
-        for I in ${PART_I}; do
-                eval PART="\${PART_REAL_$I}"
-                if test ! -b $DEVDIR/$PART; then
-                        return 1
-                fi
-        done
         if grep -q "$CPUCHECK_STRING" /proc/cpuinfo > /dev/null; then
                 return 0
         elif grep -q "$CPUCHECK_STRING" /sys/firmware/devicetree/base/model > /dev/null; then
@@ -89,41 +82,39 @@ on_device()
 # Test that $1 is a valid partition name, and that $2 is a file
 parameters_correct()
 {
-        if test -z $1 || test -z $2; then
+        if [[ -z "$1" || -z "$2" ]]; then
                 echo "Parameter(s) missing!"
-                print_help
-                exit 1
+                return 1;
         fi
-        RET=1
-        for I in ${PART_I}; do
-                eval PART="\${PART_$I}"
-                if test $PART = $1; then
-                        RET=0
-                fi
-        done
-        if test $RET = 1; then
-                echo "\"$1\" is not a supported partition!"
-        fi
-        if test -e $2 && test ! -z $2; then
-                RET=0
-        else
+        if [[ ! -e "$2" ]]; then
                 echo "No such image file \"$2\"!"
-                RET=1
+                return 1
         fi
-        return $RET
+        return 0
 }
 
 # Parameter $1 should be the partition name like "boot"
 find_device()
 {
-        for I in ${PART_I}; do
-                eval PART="\${PART_$I}"
-                if test ${PART} = $1; then
-                        return $I
-                fi
-        done
-        echo "Could not find matching partition for $1"
-        exit 1
+        if [[ $USE_BLKID -eq 1 ]]; then
+                DEVICE=$(blkid -t PARTLABEL="$1" -o device)
+        else
+                for I in ${PART_I}; do
+                        eval PART="\${PART_$I}"
+                        if [[ ${PART} = "$1" ]]; then
+                                eval DEVICE="/dev/\${PART_REAL_$I}"
+                                break
+                        fi
+                done
+        fi
+        if [[ -z "$DEVICE" ]]; then
+                echo "Could not find device for $1"
+                exit 1
+        fi
+        if [[ ! -b "$DEVICE" ]]; then
+                echo "$DEVICE is not a block device"
+                exit 1
+        fi
 }
 
 ## EXECUTION STARTS HERE ##
@@ -140,7 +131,6 @@ fi
 
 if on_device; then
         find_device $1
-        eval DEVICE=\${PART_REAL_$?}
         echo Flashing to $DEVICE
 
         # If we are flashing boot partition and we are running multirom setup
@@ -202,10 +192,10 @@ if on_device; then
         fi
 
 	if [[ "$SAILFISHOS_WIPE_PARTITIONS" == "1" ]]; then
-		dd if=/dev/zero bs=4096 $3 of=$DEVDIR/$DEVICE
+		dd if=/dev/zero bs=4096 $3 of=$DEVICE
 	fi
 
-        dd if=$FILENAME bs=4096 $3 of=$DEVDIR/$DEVICE
+        dd if=$FILENAME bs=4096 $3 of=$DEVICE
 
         if [[ "$SPARSE" == "ed26ff3a" ]]; then
                 rm -f $FILENAME

--- a/sparse/usr/sbin/flash-partition
+++ b/sparse/usr/sbin/flash-partition
@@ -96,9 +96,14 @@ parameters_correct()
 # Parameter $1 should be the partition name like "boot"
 find_device()
 {
-        if [[ $USE_BLKID -eq 1 ]]; then
+        if [[ "${1:0:1}" = "/" ]]; then
+                echo "Using provided absoulte device path"
+                DEVICE=$1
+        elif [[ $USE_BLKID -eq 1 ]]; then
+                echo "Using blkid to lookup device"
                 DEVICE=$(blkid -t PARTLABEL="$1" -o device)
         else
+                echo "Using device-info mappings to lookup device"
                 for I in ${PART_I}; do
                         eval PART="\${PART_$I}"
                         if [[ ${PART} = "$1" ]]; then


### PR DESCRIPTION
On some devices there may be multiple /dev/sdX devices and the naming order is not guaranteed. This allows using blkid to find the device instead of hardcoded mapping of labels to devices.

Also allow passing absolute device path in case more complex device lookup is needed, so that can be then done in the image specific flashing script.