### PR TITLE
[fix] Add uhid group to bluetooth.service. JB#64804

### DIFF
--- a/droid-configs.inc
+++ b/droid-configs.inc
@@ -420,10 +420,11 @@ fi
 
 # We want to keep some files in separate subpackages.
 # NOTE: some files might get to wrong place with this because of string assumption.
-%if 0%{?have_bluetooth:1}
 grep bluez5 tmp/droid-config.files > tmp/bluez5.files || true
-sed --in-place '/bluez5/d' tmp/droid-config.files
-%endif
+grep "/etc/obexd" tmp/droid-config.files >> tmp/bluez5.files || true
+grep bluetooth.service.d tmp/droid-config.files >> tmp/bluez5.files || true
+delete_files tmp/droid-config.files tmp/bluez5.files %{!?have_bluetooth:1}
+
 grep ohm tmp/droid-config.files > tmp/policy-settings.files
 sed --in-place '/ohm/d' tmp/droid-config.files
 grep pulse tmp/droid-config.files > tmp/pulseaudio-settings.files

--- a/sparse/usr/lib/systemd/system/bluetooth.service.d/uhid.conf
+++ b/sparse/usr/lib/systemd/system/bluetooth.service.d/uhid.conf
@@ -1,0 +1,3 @@
+[Service]
+# Android HAL sets /dev/uhid owner and group to uhid
+SupplementaryGroups=uhid


### PR DESCRIPTION
The uhid group was introduced in Andorid 8.1, so devices using older base need to add this in the delete_file.list