### PR TITLE
configs: Map the keypad star and pound keys on kmap

### DIFF
--- a/configs/droid.kmap
+++ b/configs/droid.kmap
@@ -24,3 +24,6 @@ keycode 528 = CameraFocus
 keycode 766 = Camera
 # custom assistant button on at least Sony Xperia 10 III
 keycode 457 = Camera
+# 12-key keypad (Callback): * and #, KEY_NUMERIC_STAR and KEY_NUMERIC_POUND
+keycode 522 = asterisk
+keycode 523 = numbersign


### PR DESCRIPTION
A 12-key keypad (Callback) emits KEY_NUMERIC_STAR (522) and KEY_NUMERIC_POUND (523). Without these lines lipstick's evdev plugin drops both keys. The matching keysyms come from xkeyboard-config's jolla:keypad option.

[configs] Map the keypad star and pound keys on kmap. JB#65137